### PR TITLE
feat: add a contact call to action to the home page

### DIFF
--- a/config.php
+++ b/config.php
@@ -6,6 +6,7 @@ return [
     'siteName' => 'Hesam Rad',
     'siteDescription' => 'Software Engineer',
     'siteAuthor' => 'Hesam Rad',
+    'email' => 'hesamrad.dev@gmail.com',
     // Defaults. Individual pages override these via `locale`/`language` front
     // matter; posts fall back to the post-specific pair below.
     'defaultLocale' => 'en_US',

--- a/source/_assets/css/style.css
+++ b/source/_assets/css/style.css
@@ -316,3 +316,97 @@ header h1 {
 .next p {
     margin: 0;
 }
+
+/* Contact call to action. It opens on the same hairline `hr` uses instead of
+   sitting in a box, so it reads as the closing note of the page rather than an
+   advert pasted onto it. */
+.hero {
+    margin-top: calc(4 * var(--space));
+    padding-top: calc(3 * var(--space));
+    border-top: 1px solid var(--border-color);
+}
+
+.hero-overline {
+    font-size: 0.889rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: calc(0.5 * var(--space)) !important;
+}
+
+.hero-dot {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background-color: var(--primary-color);
+    margin-inline-end: 0.6em;
+    vertical-align: middle;
+    animation: hero-pulse 3s ease-in-out infinite;
+}
+
+.hero-title {
+    margin-bottom: calc(0.5 * var(--space)) !important;
+    text-wrap: balance;
+}
+
+.hero-body {
+    /* A shorter measure than the body copy: the eye should land on the button. */
+    max-width: 32em;
+    margin-bottom: calc(1.5 * var(--space)) !important;
+    text-wrap: pretty;
+}
+
+.hero-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5em;
+    padding: calc(0.6 * var(--space)) calc(1.4 * var(--space));
+    background-color: var(--primary-color);
+    /* Wins over the blanket `a { color: var(--primary-color) }` above. */
+    color: var(--header-color) !important;
+    border-radius: var(--border-radius);
+    font-weight: 600;
+    line-height: 1.6;
+    transition: background-color 0.2s ease;
+}
+
+.hero-cta:hover {
+    background-color: color-mix(in srgb, var(--primary-color), black 12%);
+}
+
+.hero-cta:focus-visible {
+    outline: 2px solid var(--header-color);
+    outline-offset: 3px;
+}
+
+.hero-arrow {
+    transition: transform 0.2s ease;
+}
+
+.hero-cta:hover .hero-arrow {
+    transform: translateX(3px);
+}
+
+/* The glyph points at the end of the line, so under RTL it leans the other way. */
+[dir='rtl'] .hero-cta:hover .hero-arrow {
+    transform: translateX(-3px);
+}
+
+@keyframes hero-pulse {
+    50% {
+        opacity: 0.35;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+    .hero-dot,
+    .hero-arrow {
+        animation: none;
+        transition: none;
+    }
+
+    .hero-cta:hover .hero-arrow {
+        transform: none;
+    }
+}

--- a/source/_assets/css/variables.css
+++ b/source/_assets/css/variables.css
@@ -1,5 +1,9 @@
 :root {
     --primary-color: #ff4d00;
+    /* Ink for text sitting *on* the primary color. Fixed in both schemes
+       because the orange underneath it never changes: white on that orange is
+       only 3.3:1, this is 5.6:1. */
+    --on-primary-color: #131313;
 
     --space: 1rem;
     --font-family: 'Noto Sans', 'Open Sans', sans-serif;

--- a/source/_components/hero.blade.php
+++ b/source/_components/hero.blade.php
@@ -1,0 +1,20 @@
+{{-- A standalone call to action. It is deliberately self-contained so it can be
+     dropped at the end of any page — home, projects, a post — without the page
+     having to know anything about it. --}}
+<section class="hero">
+    <p class="hero-overline">
+        <span class="hero-dot" aria-hidden="true"></span>
+        Available for new projects
+    </p>
+
+    <h2 class="hero-title">Let's build something.</h2>
+
+    <p class="hero-body">If you have a product in mind — or one that needs rescuing — tell me
+        about it. I read every email and reply to the ones I can help with.</p>
+
+    <a class="hero-cta" href="mailto:{{ $page->email }}?subject={{ rawurlencode('A new project') }}">
+        Start a conversation
+        {{-- Decorative: the link text already says where it goes. --}}
+        <i class="fa-solid fa-arrow-right ml-05"></i>
+    </a>
+</section>

--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -5,7 +5,7 @@
 @section('description', 'Software Engineer with ' . $page->getMyYearsOfExperience() . '+ years of experience in building products for the internet.')
 
 @section('content')
-    <p class="mb-3">Hello, I am Hesam.</p>
+    <p class="mb-3 hero-overline">Hello, I am Hesam.</p>
     <h1>I build software.</h1>
 
     <p>I have been building web-based software since 2017 when I was still in college. Every once in a while, I
@@ -14,7 +14,9 @@
         is spent reading books.</p>
 
     <p>I mindfully employ digital minimalism in my life; but you can still reach me by sending an <a
-            href="mailto:hesamrad.dev@gmail.com">email</a> or visiting my <a href="https://linkedin.com/in/hesamrad"
+            href="mailto:{{ $page->email }}">email</a> or visiting my <a href="https://linkedin.com/in/hesamrad"
             target="_blank" rel="noopener noreferrer">LinkedIn</a> or <a href="https://github.com/hesamzakerirad" target="_blank" rel="noopener noreferrer">GitHub</a>
         page.</p>
+
+    @include('_components.hero')
 @endsection


### PR DESCRIPTION
Closes the home page with a short prompt to get in touch, rather than letting it end on the reading-books line.

## What's here

- A `hero` section on the home page, opening on the same hairline `hr` uses instead of sitting in a box, so it reads as the closing note of the page rather than an advert pasted onto it.
- An `email` config key, so the mailto address isn't hardcoded in the template.
- The page's opening line ("Hello, I am Hesam.") marked as a hero overline.
- The arrow uses the Font Awesome icon already used by the back-links and post navigation, rather than a `&rarr;` glyph.

## Why this is a separate PR

This work was authored locally and was sitting uncommitted. I swept it into an unrelated commit on `main` by mistake (`b29e59d`, whose message claimed it was a one-line 404 canonical fix) and pushed it. That commit has been reverted on `main` in `4703cdd`, and the feature is re-proposed here on its own so it can be reviewed on its merits.

## Two things worth a look before merging

**The arrow's hover animation no longer fires.** Five rules in `style.css` still key off `.hero-arrow` — the `translateX(3px)` hover slide, its RTL mirror, and the `prefers-reduced-motion` guard — but the markup now uses `<i class="fa-solid fa-arrow-right ml-05">`. Nothing matches those selectors, so the arrow is static on hover and roughly 20 lines of CSS are orphaned. Either restore the class alongside the icon or drop the dead rules.

**The call-to-action label fails WCAG AA in dark mode.** The label was recoloured from `--on-primary-color` to `--header-color`, which flips with the theme while the orange button does not:

| Foreground on `#ff4d00` | Ratio | AA (4.5:1) |
|---|---|---|
| `--on-primary-color` `#131313` (before) | 5.59:1 | passes |
| `--header-color` `#222221` (light, after) | 4.79:1 | passes |
| `--header-color` `#ffffff` (dark, after) | **3.33:1** | **fails** |

White on that orange is the one combination below the threshold. `--on-primary-color` is still defined at `variables.css:6` if the swap was made because it looked unused.

Verified: `npm run prod` and `jigsaw build production` both succeed, and the section renders on the home page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)