### PR TITLE
Redesign the about page around the work

### DIFF
--- a/source/_assets/css/components.css
+++ b/source/_assets/css/components.css
@@ -2145,3 +2145,10 @@ textarea.field__input {
     margin-top: var(--space-lg);
     text-align: center;
 }
+
+/* The section heading above this link is centred, therefore the link is too. */
+.work__more {
+    margin-top: var(--space-lg);
+    margin-bottom: 0;
+    text-align: center;
+}

--- a/source/_assets/css/components.css
+++ b/source/_assets/css/components.css
@@ -1848,18 +1848,46 @@ textarea.field__input {
     transform: translateX(4px);
 }
 
-.about__portrait {
-    max-width: 22rem;
-    border-radius: var(--radius-lg);
-    overflow: hidden;
+/*
+ * A heading in a narrow column beside the text it introduces.
+ *
+ * The aside column is fixed and the body column takes the rest, therefore the
+ * headings of two `.split` sections align with each other. `.grid--halves`
+ * gives each column half the width, which leaves a long heading beside a short
+ * measure of text.
+ *
+ * responsive.css makes this one column on a narrow screen.
+ */
+.split {
+    display: grid;
+    grid-template-columns: minmax(0, 16rem) minmax(0, 1fr);
+    gap: var(--space-lg) var(--space-xl);
+    align-items: start;
 }
 
-.about__portrait .ph,
-.about__portrait img {
-    display: block;
-    width: 100%;
-    aspect-ratio: 4 / 5;
-    object-fit: cover;
+.split__aside > :first-child {
+    margin-top: 0;
+}
+
+/* A section heading at its full size wraps to three lines in a 16rem column.
+   The heading is a label for the column beside it, therefore it takes the
+   step below. */
+.split__aside h2 {
+    font-size: var(--text-xl);
+    text-wrap: balance;
+}
+
+.split__body {
+    max-width: var(--measure);
+}
+
+.split__body > p {
+    margin-top: 0;
+    margin-bottom: var(--space-md);
+}
+
+.split__body > p:last-child {
+    margin-bottom: 0;
 }
 
 .study__cover-note {

--- a/source/_assets/css/responsive.css
+++ b/source/_assets/css/responsive.css
@@ -17,6 +17,13 @@
         align-items: flex-start;
     }
 
+    /* One column. A 16rem aside beside the text leaves neither column a
+       readable width on a phone. */
+    .split {
+        grid-template-columns: minmax(0, 1fr);
+        gap: var(--space-md);
+    }
+
     .site-footer__bottom {
         flex-direction: column;
     }

--- a/source/_components/work-card.blade.php
+++ b/source/_components/work-card.blade.php
@@ -1,0 +1,46 @@
+{{--
+    One case study, as a card. /work/ lists them all and /about/ shows a
+    selection.
+
+    Parameters:
+      $study      — an item of the caseStudies collection
+      $titleLevel — the heading level of the card title  (default 2)
+
+    Set $titleLevel to 3 when a section heading is above the list. On /work/
+    the <h1> is the page title, therefore the card title is an <h2>. On
+    /about/ an <h2> introduces the list, therefore the card title is an <h3>.
+--}}
+@php
+    // Use getCover() and do not read cover['src'] directly. Front matter writes
+    // the cover as a bare URL and also as a map. A study that uses the URL form
+    // shows no image.
+    $cover = $study->getCover();
+    $level = $titleLevel ?? 2;
+@endphp
+
+<article class="work-card">
+    {{-- The image is decorative. The title anchor covers the whole card. --}}
+    @if ($cover && $cover['src'])
+        <img class="work-card__bg" src="{{ $cover['src'] }}" alt="" aria-hidden="true"
+            loading="lazy" decoding="async" width="1600" height="900">
+    @endif
+
+    @if ($study->sample ?? false)
+        <p class="case__flag">Invented sample, not real work</p>
+    @endif
+
+    <h{{ $level }} class="work-card__title">
+        {{-- The ::after of this anchor covers the whole card. Keep one link
+             only in the card. --}}
+        <a href="{{ $study->getCanonicalUrl() }}">{{ $study->title }}</a>
+    </h{{ $level }}>
+
+    <p class="work-card__summary">{{ $study->summary }}</p>
+
+    <p class="work-card__more">
+        <span class="link-arrow">
+            <span>Read the whole story</span>
+            @include('_components.icon', ['name' => 'arrow-right'])
+        </span>
+    </p>
+</article>

--- a/source/about.blade.php
+++ b/source/about.blade.php
@@ -6,7 +6,9 @@ title: About
 
 @section('title', 'About Hesam Rad')
 
-@section('description', 'Independent software engineer. Eight years building web software for businesses, five of them looking after a single system for one client.')
+@section('description',
+    'Independent software engineer. Eight years building web software for businesses, five of them
+    looking after a single system for one client.')
 
 @section('body')
     <div class="shell section page-head">
@@ -15,11 +17,12 @@ title: About
 
         <h1>Hesam Rad.</h1>
 
-        <p class="lead prose">I build the software businesses run on, and I've been doing it since 2017. That started
-            while I was still a computer engineering student, and it's been full time on my own since late 2025.</p>
+        <p class="lead prose">I help businesses grow by building them software they can use and rely on
+            to move forward with their digital journey and I have been doing it since 2017.
+        </p>
 
-        <p class="lead prose">Most of what I do is the part customers never see: the system underneath, the data in it,
-            and the work of keeping both correct once real people depend on them.</p>
+        <p class="lead prose">Most of what I do is understanding what the problem is so I can build the right tool to fix it.
+        </p>
     </div>
 
     {{-- The heading holds the left column and the prose holds the right one.
@@ -32,16 +35,21 @@ title: About
             </div>
 
             <div class="split__body">
-                <p>I spent five years as lead engineer on a digital menu platform, and most of another building a
-                    monitoring system for a brokerage. Both were the same shape of work: one engineer who knew the
-                    whole system, answerable for it, still there a year later.</p>
 
-                <p>That's the arrangement I kept choosing, so eventually I stopped pretending it needed a company
-                    around it. There's no agency here and no team to brief. The person you email is the person who
-                    writes the code, and the person who fixes it at eleven at night.</p>
-
-                <p>I take on the work I'm good at. When something isn't that, I say so on the first call instead of
-                    three weeks in. It costs me the occasional project and it has never once cost me a client.</p>
+                <p>
+                    In my experience as an employed engineer, the software an entire business relies on is often built and
+                    maintained by a handful of people who know it end to end. In my case, I was always one of those people,
+                    responsible not just for writing the code, but for understanding the system, making decisions, and
+                    keeping it running.
+                </p>
+                <p>
+                    Eventually, I realized I didn't need a company around me to take that responsibility seriously. I could
+                    work directly with a business, understand what it needs, and care about the software as deeply as the
+                    people who depend on it.
+                </p>
+                <p>
+                    So I started working independently in late 2025.
+                </p>
             </div>
         </div>
     </section>
@@ -49,28 +57,37 @@ title: About
     <section class="section section--band">
         <div class="shell">
             <div class="section-head">
-                <h2>What eight years taught me.</h2>
-                <p>Three things I didn't believe at the start and would now argue for at length.</p>
+                <h2>The software is only half the job.</h2>
+                <p>The other half is everything around it: how I work with you, what you can see while it happens,
+                    and what you're left holding at the end.</p>
             </div>
 
             @php
-                $beliefs = [
+                $risks = [
                     [
-                        'title' => 'The hard part is deciding, not building',
-                        'body' => 'Almost every project that goes badly went wrong before any code was written, in a conversation nobody had. I spend the first few days asking questions that sound obvious, because the alternative is building the wrong thing quickly.',
+                        'title' => 'Commitment',
+                        'body' =>
+                            'I take on a small number of projects and I stay with them. Your work isn\'t fitted around six other clients, and I\'m not gone the week after it goes live.',
                     ],
                     [
-                        'title' => 'Software you cannot change is already broken',
-                        'body' => 'Anything worth building gets changed. If a change is frightening, the system has failed you whether or not it happens to work today. That\'s why the tests, the release process and the documentation get treated as part of the job rather than as overhead.',
+                        'title' => 'Trust',
+                        'body' =>
+                            'You\'re handing over something the business depends on. One person is answerable for all of it, and when something goes wrong it gets fixed first and explained after.',
                     ],
                     [
-                        'title' => 'Explaining it plainly is part of the job',
-                        'body' => 'If you can\'t follow what I\'m telling you, you can\'t judge whether I\'m right, and you\'re back to trusting a stranger. Every technical decision here has a plain-English version, and I\'d rather give you that than sound clever.',
+                        'title' => 'Transparency',
+                        'body' =>
+                            'You always know where things stand. Progress is something you look at rather than something I report, and every decision comes with a reason in plain English.',
+                    ],
+                    [
+                        'title' => 'Ownership',
+                        'body' =>
+                            'The domain, the accounts and the code are in your name from day one. Nothing runs only on my laptop, so replacing me is never a rescue operation.',
                     ],
                 ];
             @endphp
 
-            @include('_components.card-grid', ['items' => $beliefs, 'grid' => 'cards'])
+            @include('_components.card-grid', ['items' => $risks, 'grid' => 'cards'])
         </div>
     </section>
 

--- a/source/about.blade.php
+++ b/source/about.blade.php
@@ -96,7 +96,7 @@ title: About
                 @endforeach
             </div>
 
-            <p class="mt-lg">
+            <p class="work__more">
                 <a class="link-arrow" href="{{ $page->baseUrl }}/work/">
                     <span>All case studies</span>
                     @include('_components.icon', ['name' => 'arrow-right'])

--- a/source/about.blade.php
+++ b/source/about.blade.php
@@ -22,32 +22,26 @@ title: About
             and the work of keeping both correct once real people depend on them.</p>
     </div>
 
+    {{-- The heading holds the left column and the prose holds the right one.
+         The heading stays beside the text it introduces, and the text keeps a
+         readable measure without a rule or a panel around it. --}}
     <section class="shell section">
-        <div class="grid grid--halves">
-            <div class="about__portrait">
-                {{-- To add the photograph, replace this include with an <img>.
-                     The layout does not change. --}}
-                @include('_components.image-placeholder', [
-                    'ratio' => 'portrait',
-                    'label' => 'photograph of Hesam Rad',
-                    'note' => 'Photograph to come',
-                ])
+        <div class="split">
+            <div class="split__aside">
+                <h2>How I ended up working alone.</h2>
             </div>
 
-            <div class="section-head section-head--start">
-                <h2>How I ended up working alone.</h2>
+            <div class="split__body">
+                <p>I spent five years as lead engineer on a digital menu platform, and most of another building a
+                    monitoring system for a brokerage. Both were the same shape of work: one engineer who knew the
+                    whole system, answerable for it, still there a year later.</p>
 
-                <p class="dim">I spent five years as lead engineer on a digital menu platform, and most of another
-                    building a monitoring system for a brokerage. Both were the same shape of work: one engineer who
-                    knew the whole system, answerable for it, still there a year later.</p>
+                <p>That's the arrangement I kept choosing, so eventually I stopped pretending it needed a company
+                    around it. There's no agency here and no team to brief. The person you email is the person who
+                    writes the code, and the person who fixes it at eleven at night.</p>
 
-                <p class="dim">That's the arrangement I kept choosing, so eventually I stopped pretending it needed a
-                    company around it. There's no agency here and no team to brief. The person you email is the person
-                    who writes the code, and the person who fixes it at eleven at night.</p>
-
-                <p class="dim">I take on the work I'm good at. When something isn't that, I say so on the first call
-                    instead of three weeks in. It costs me the occasional project and it has never once cost me a
-                    client.</p>
+                <p>I take on the work I'm good at. When something isn't that, I say so on the first call instead of
+                    three weeks in. It costs me the occasional project and it has never once cost me a client.</p>
             </div>
         </div>
     </section>
@@ -80,45 +74,36 @@ title: About
         </div>
     </section>
 
-    <section class="shell section">
-        <div class="grid grid--halves">
-            <div class="section-head section-head--start">
-                <h2>There's a person behind this.</h2>
+    @php
+        // The collection filter in config.php removes each sample when the site
+        // is public, therefore this template does not test for samples again.
+        $selected = $caseStudies->sortByDesc('year')->take(2);
+    @endphp
 
-                <p class="dim">I have a literary background as well as an engineering one, and I'm reading for a
-                    master's in English literature. Most of the time I'm not writing code, I'm reading.</p>
-
-                <p class="dim">It's less of a detour than it sounds. Both jobs are mostly about saying a complicated
-                    thing clearly to somebody who has no reason to be patient with you.</p>
-
-                <p class="dim">I'm on very few platforms, by choice. Email reaches me faster than anything else
-                    does.</p>
+    @if ($page->workIsPublic && $selected->isNotEmpty())
+        <section class="shell section">
+            <div class="section-head">
+                <h2>Some of what I have built.</h2>
+                <p>Each one was a single engineer on a single system for years. The write-ups say what the business
+                    needed, what I built, and what changed.</p>
             </div>
 
-            <div class="rows">
-                <div class="row">
-                    <p class="row__key">Since 2017</p>
-                    <div class="row__value">
-                        <p>Building web software, starting while I was still a computer engineering student.</p>
-                    </div>
-                </div>
-                <div class="row">
-                    <p class="row__key">Where I work</p>
-                    <div class="row__value">
-                        <p>Remote, with clients across Europe and North America. I arrange my day around whichever
-                            of those you're in, so there are hours every day when you can reach me.</p>
-                    </div>
-                </div>
-                <div class="row">
-                    <p class="row__key">Open source</p>
-                    <div class="row__value">
-                        <p>Four small tools I kept needing and eventually published, plus a free URL shortener built as
-                            a non-profit. <a href="{{ $page->baseUrl }}/projects/">See the code</a>.</p>
-                    </div>
-                </div>
+            <div class="work-list mt-lg">
+                @foreach ($selected as $study)
+                    {{-- An <h2> introduces this list, therefore the card title
+                         is an <h3>. --}}
+                    @include('_components.work-card', ['study' => $study, 'titleLevel' => 3])
+                @endforeach
             </div>
-        </div>
-    </section>
+
+            <p class="mt-lg">
+                <a class="link-arrow" href="{{ $page->baseUrl }}/work/">
+                    <span>All case studies</span>
+                    @include('_components.icon', ['name' => 'arrow-right'])
+                </a>
+            </p>
+        </section>
+    @endif
 
     @include('_components.testimonials')
 

--- a/source/work.blade.php
+++ b/source/work.blade.php
@@ -52,42 +52,7 @@ title: Work
 
             <div class="work-list mt-lg">
                 @foreach ($studies as $study)
-                    {{-- Use getCover() and do not read cover['src'] directly.
-                         Front matter writes the cover as a bare URL and also as
-                         a map. A study that uses the URL form shows no image. --}}
-                    {{-- Use a block @php. An inline @php is safe only in a file
-                         with no later @php…@endphp. --}}
-                    @php
-                        $cover = $study->getCover();
-                    @endphp
-
-                    <article class="work-card">
-                        {{-- The image is decorative. The title anchor covers the
-                             whole card. --}}
-                        @if ($cover && $cover['src'])
-                            <img class="work-card__bg" src="{{ $cover['src'] }}" alt="" aria-hidden="true"
-                                loading="lazy" decoding="async" width="1600" height="900">
-                        @endif
-
-                        @if ($study->sample ?? false)
-                            <p class="case__flag">Invented sample, not real work</p>
-                        @endif
-
-                        <h2 class="work-card__title">
-                            {{-- The ::after of this anchor covers the whole
-                                 card. Keep one link only in the card. --}}
-                            <a href="{{ $study->getCanonicalUrl() }}">{{ $study->title }}</a>
-                        </h2>
-
-                        <p class="work-card__summary">{{ $study->summary }}</p>
-
-                        <p class="work-card__more">
-                            <span class="link-arrow">
-                                <span>Read the whole story</span>
-                                @include('_components.icon', ['name' => 'arrow-right'])
-                            </span>
-                        </p>
-                    </article>
+                    @include('_components.work-card', ['study' => $study])
                 @endforeach
             </div>
         @endif


### PR DESCRIPTION
## What changed

**The portrait is gone.** It was an empty wireframe reading "Photograph to come". A page trying to look finished cannot carry a placeholder box as its second element. Removed with its CSS; the intro runs full width. Drops straight back in when there is a photograph.

**"There's a person behind this" is replaced by the work.** Both case studies, each linking to its write-up, with a link to `/work/` below them.

**"How I ended up working alone" moves to a new `.split` layout.** The heading sits in a fixed 16rem column beside the prose. Fixed rather than `.grid--halves`, so the headings of two split sections line up with each other — halves gives each column half the width, which puts a long heading beside a short measure of text. The heading takes one step down the type scale, because at full size it wraps to three lines in that column.

**The card is a component now.** `.work-card` markup was inline in `work.blade.php`; two pages render it, so it is `_components/work-card.blade.php`. It takes `$titleLevel` — `/work/` has an `<h1>` above it and passes 2, `/about/` has an `<h2>` and passes 3.

## Verified

Measured in the browser rather than eyeballed:

- Heading order is `h1 → h2 → h3` with no skipped level on either page.
- `/work/` still renders 2 cards at `h2` with covers; `/about/` renders the same 2 at `h3`. Same markup, one source.
- No horizontal overflow at 1280 or at 375. The split stacks to one column below 768px.
- Dark mode checked: cards keep their cover scrim and legible white type.
- Section bands now alternate plain / band / plain / band / plain. Removing a section left two bands flush on the home page in #21, so this was checked deliberately.

## Worth knowing

The removed section held the facts list as well as the prose, so `/about/` no longer links to `/projects/`. The footer still does, so the page is not orphaned — flagging it because it was not the point of the change.

The body prose in the split lost its `.dim` class. At full contrast beside a quiet heading it reads better than dimmed text did beside a portrait. Say if you want it back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)