### PR TITLE
content: american spelling site-wide, and de-templated FAQ answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,11 @@ The CSS has five files. Each file has one purpose:
 
 | File | Purpose |
 | --- | --- |
-| `tokens.css` | Every colour, size and space value |
+| `tokens.css` | Every color, size and space value |
 | `base.css` | Element defaults |
 | `layout.css` | The page frame, the header, the hero |
 | `components.css` | Cards, forms, the FAQ and the other parts |
-| `syntax.css` | Colours for code blocks |
+| `syntax.css` | Colors for code blocks |
 
 ## Add a blog post
 
@@ -202,7 +202,7 @@ prevents a flash of the wrong theme.
 The header has a button that changes the theme. The choice is kept in the
 browser.
 
-Do not write a colour value in a rule. Use a token from `tokens.css`. Each
+Do not write a color value in a rule. Use a token from `tokens.css`. Each
 token has a value in the light theme and a value in the dark theme. This is
 what makes the dark theme possible to check.
 
@@ -251,14 +251,14 @@ needs the `.ttf` files to make them.
 
 **To rebuild the mark.** This writes both `source/_assets/images/logo.svg` and
 `source/favicon.ico` from one set of numbers. Run it after you change the
-geometry or a colour in the script:
+geometry or a color in the script:
 
 ```bash
 .venv/bin/python build_mark.py
 ```
 
 **To rebuild the share card.** Run this after you change the headline or a
-colour:
+color:
 
 ```bash
 .venv/bin/pip install Pillow
@@ -277,12 +277,12 @@ site key is public. The secret key is not in this repository.
 To set up the Worker, or to read the stored enquiries, see
 [worker/README.md](worker/README.md).
 
-## Licence
+## License
 
-`LICENSE.txt` is the MIT licence of the Jigsaw blog template. It arrived with
-the template in the first commit, and it is not a licence for this site. The
+`LICENSE.txt` is the MIT license of the Jigsaw blog template. It arrived with
+the template in the first commit, and it is not a license for this site. The
 copyright line names the template authors.
 
-This site has no licence of its own yet. Add one, or delete `LICENSE.txt`.
+This site has no license of its own yet. Add one, or delete `LICENSE.txt`.
 Until then, no person has permission to reuse the code, the written content or
 the images.

--- a/build_mark.py
+++ b/build_mark.py
@@ -5,10 +5,10 @@ Draws the site mark: source/_assets/images/logo.svg and source/favicon.ico.
     .venv/bin/python build_mark.py
 
 The mark is a four-fold rosette: four petals on the diagonals, four dots on the
-axes, and a ring of small lobes around a disc at the centre.
+axes, and a ring of small lobes around a disc at the center.
 
 One set of numbers makes both files. The SVG and the icon therefore cannot
-disagree about the shape. All geometry is in a 512 unit square with the centre
+disagree about the shape. All geometry is in a 512 unit square with the center
 at (256, 256). The SVG keeps those units. The icon scales them.
 
 The icon has two levels of detail. The full mark needs approximately 24 pixels.
@@ -40,31 +40,31 @@ ACCENT_LIGHT = "#0066cc"
 ACCENT_DARK = "#2997ff"
 
 UNITS = 512
-CENTRE = UNITS / 2
+CENTER = UNITS / 2
 
-# Four petals on the diagonals. `dist` is the distance from the centre of the
-# mark to the centre of the petal. The tip therefore reaches dist + ry, which
+# Four petals on the diagonals. `dist` is the distance from the center of the
+# mark to the center of the petal. The tip therefore reaches dist + ry, which
 # is 348 of a possible 362 to the corner.
 PETAL = {"dist": 203, "rx": 51, "ry": 145}
 
 # Four dots on the axes, between the petals.
 DOT = {"dist": 183, "r": 33}
 
-# The rosette. The lobes reach ROSETTE_LOBE["dist"] + ry from the centre, which
+# The rosette. The lobes reach ROSETTE_LOBE["dist"] + ry from the center, which
 # stays inside the tips of the petals at 58.
 ROSETTE_DISC = 23
 ROSETTE_RING = {"r": 31, "width": 3.5}
 ROSETTE_LOBE = {"count": 16, "dist": 41, "rx": 7, "ry": 10}
 
 # The small icon. The disc replaces the rosette and covers the same area as the
-# ring, therefore the mark keeps its weight at the centre. The petals get wider
+# ring, therefore the mark keeps its weight at the center. The petals get wider
 # to hold their shape at 16 pixels.
 ROSETTE_SIMPLE = 30
 SMALL_PETAL_SCALE = 1.25
 
 
 def ellipse_points(cx, cy, rx, ry, angle_deg, steps=240):
-    """An ellipse as a polygon, rotated `angle_deg` about the centre of the mark.
+    """An ellipse as a polygon, rotated `angle_deg` about the center of the mark.
 
     PIL cannot draw a rotated ellipse. A polygon of this many segments is
     smooth at every size this file writes.
@@ -75,10 +75,10 @@ def ellipse_points(cx, cy, rx, ry, angle_deg, steps=240):
 
     for step in range(steps):
         theta = 2 * math.pi * step / steps
-        # The point on the unrotated ellipse, relative to the centre of the mark.
-        x = cx - CENTRE + rx * math.cos(theta)
-        y = cy - CENTRE + ry * math.sin(theta)
-        points.append((CENTRE + x * cos_a - y * sin_a, CENTRE + x * sin_a + y * cos_a))
+        # The point on the unrotated ellipse, relative to the center of the mark.
+        x = cx - CENTER + rx * math.cos(theta)
+        y = cy - CENTER + ry * math.sin(theta)
+        points.append((CENTER + x * cos_a - y * sin_a, CENTER + x * sin_a + y * cos_a))
 
     return points
 
@@ -101,32 +101,32 @@ def svg(colour_light=ACCENT_LIGHT, colour_dark=ACCENT_DARK):
 
     for angle in (45, 135, 225, 315):
         parts.append(
-            f'        <ellipse cx="{CENTRE:g}" cy="{CENTRE - PETAL["dist"]:g}"'
+            f'        <ellipse cx="{CENTER:g}" cy="{CENTER - PETAL["dist"]:g}"'
             f' rx="{PETAL["rx"]:g}" ry="{PETAL["ry"]:g}"'
-            f' transform="rotate({angle} {CENTRE:g} {CENTRE:g})"/>'
+            f' transform="rotate({angle} {CENTER:g} {CENTER:g})"/>'
         )
 
     parts.append("        <!-- Four dots, on the axes. -->")
     for angle in (0, 90, 180, 270):
         parts.append(
-            f'        <circle cx="{CENTRE:g}" cy="{CENTRE - DOT["dist"]:g}"'
+            f'        <circle cx="{CENTER:g}" cy="{CENTER - DOT["dist"]:g}"'
             f' r="{DOT["r"]:g}"'
-            f' transform="rotate({angle} {CENTRE:g} {CENTRE:g})"/>'
+            f' transform="rotate({angle} {CENTER:g} {CENTER:g})"/>'
         )
 
     parts.append("        <!-- The rosette: lobes, then a ring, then a disc. -->")
     for index in range(ROSETTE_LOBE["count"]):
         angle = 360 * index / ROSETTE_LOBE["count"]
         parts.append(
-            f'        <ellipse cx="{CENTRE:g}" cy="{CENTRE - ROSETTE_LOBE["dist"]:g}"'
+            f'        <ellipse cx="{CENTER:g}" cy="{CENTER - ROSETTE_LOBE["dist"]:g}"'
             f' rx="{ROSETTE_LOBE["rx"]:g}" ry="{ROSETTE_LOBE["ry"]:g}"'
-            f' transform="rotate({angle:g} {CENTRE:g} {CENTRE:g})"/>'
+            f' transform="rotate({angle:g} {CENTER:g} {CENTER:g})"/>'
         )
 
     parts += [
-        f'        <circle cx="{CENTRE:g}" cy="{CENTRE:g}" r="{ROSETTE_RING["r"]:g}"'
+        f'        <circle cx="{CENTER:g}" cy="{CENTER:g}" r="{ROSETTE_RING["r"]:g}"'
         f' fill="none" stroke-width="{ROSETTE_RING["width"]:g}"/>',
-        f'        <circle cx="{CENTRE:g}" cy="{CENTRE:g}" r="{ROSETTE_DISC:g}"/>',
+        f'        <circle cx="{CENTER:g}" cy="{CENTER:g}" r="{ROSETTE_DISC:g}"/>',
         "    </g>",
         "</svg>",
         "",
@@ -148,7 +148,7 @@ def raster(size, detailed=True, render=1024):
     for angle in (45, 135, 225, 315):
         draw.polygon(
             [(at(x), at(y)) for x, y in ellipse_points(
-                CENTRE, CENTRE - PETAL["dist"], petal_rx, PETAL["ry"], angle)],
+                CENTER, CENTER - PETAL["dist"], petal_rx, PETAL["ry"], angle)],
             fill=fill,
         )
 
@@ -158,7 +158,7 @@ def raster(size, detailed=True, render=1024):
         for angle in (0, 90, 180, 270):
             draw.polygon(
                 [(at(x), at(y)) for x, y in ellipse_points(
-                    CENTRE, CENTRE - DOT["dist"], DOT["r"], DOT["r"], angle)],
+                    CENTER, CENTER - DOT["dist"], DOT["r"], DOT["r"], angle)],
                 fill=fill,
             )
 
@@ -167,15 +167,15 @@ def raster(size, detailed=True, render=1024):
             angle = 360 * index / ROSETTE_LOBE["count"]
             draw.polygon(
                 [(at(x), at(y)) for x, y in ellipse_points(
-                    CENTRE, CENTRE - ROSETTE_LOBE["dist"],
+                    CENTER, CENTER - ROSETTE_LOBE["dist"],
                     ROSETTE_LOBE["rx"], ROSETTE_LOBE["ry"], angle)],
                 fill=fill,
             )
 
         radius, width = ROSETTE_RING["r"], ROSETTE_RING["width"] / 2
         draw.ellipse(
-            [at(CENTRE - radius - width), at(CENTRE - radius - width),
-             at(CENTRE + radius + width), at(CENTRE + radius + width)],
+            [at(CENTER - radius - width), at(CENTER - radius - width),
+             at(CENTER + radius + width), at(CENTER + radius + width)],
             outline=fill, width=max(1, round(at(ROSETTE_RING["width"]))),
         )
         disc = ROSETTE_DISC
@@ -183,7 +183,7 @@ def raster(size, detailed=True, render=1024):
         disc = ROSETTE_SIMPLE
 
     draw.ellipse(
-        [at(CENTRE - disc), at(CENTRE - disc), at(CENTRE + disc), at(CENTRE + disc)],
+        [at(CENTER - disc), at(CENTER - disc), at(CENTER + disc), at(CENTER + disc)],
         fill=fill,
     )
 
@@ -211,7 +211,7 @@ def ico(entries):
             size if size < 256 else 0,
             0,  # palette entries: 0 for a PNG payload
             0,  # reserved
-            1,  # colour planes
+            1,  # color planes
             32,  # bits per pixel
             len(data),
             offset,

--- a/build_og_image.py
+++ b/build_og_image.py
@@ -52,7 +52,7 @@ def main():
 
     margin = 88
 
-    # The accent bar. The one piece of colour, and the only thing marking this
+    # The accent bar. The one piece of color, and the only thing marking this
     # as ours rather than any other white card in a feed.
     draw.rounded_rectangle([margin, margin, margin + 64, margin + 8], radius=4, fill=ACCENT)
 

--- a/config.php
+++ b/config.php
@@ -86,7 +86,7 @@ return [
             'q' => 'What if I do not know exactly what I want yet?',
             'services' => 3,
             'a' => [
-                'That\'s the normal case, and it\'s what the first call is for. You don\'t need a specification written. You need to be able to describe what\'s wrong today and what you want instead. Working out what that means in software is part of the job I\'m being paid for, not something you have to finish before we start.',
+                'That\'s the normal case, and it\'s what the first call is for. You don\'t need a specification written. You need to be able to describe what\'s wrong today and what you\'d want instead. Working out what that means in software is part of what you\'re paying me for.',
             ],
         ],
         [
@@ -102,14 +102,14 @@ return [
             'group' => 'Before we start',
             'q' => 'How quickly will you reply?',
             'a' => [
-                'Within a day, usually sooner. I read every enquiry myself, because there\'s nobody else here to read them.',
+                'Within a day, usually sooner. I read every inquiry myself, because there\'s nobody else here to read them.',
             ],
         ],
         [
             'group' => 'Before we start',
             'q' => 'What do you need from me to get started?',
             'a' => [
-                'Half an hour on a call, and candour in it. For a Zero to One website that\'s the whole of your homework. I write the words from what you tell me, because sitting down to write a page about your own business is the step that stalls most websites for months.',
+                'Half an hour on a call, and straight answers in it. For a Zero to One website that\'s the whole of your homework. I write the words from what you tell me, because sitting down to write a page about your own business is the step that stalls most websites for months.',
                 'For larger work you\'ll also need to be reachable for a short call each week. Nothing else is needed up front: no specification, no wireframes, no list of features.',
             ],
         ],
@@ -122,7 +122,7 @@ return [
             'open' => true,
             'a' => [
                 'The cheapest way in is Zero to One: a fixed website for ' . $pricing['symbol'] . number_format($pricing['setup']) . ', plus ' . $pricing['symbol'] . number_format($pricing['monthly']) . ' a month to keep it running. For a lot of businesses that\'s the whole answer.',
-                'Anything past that is a fixed price for a defined project, or a monthly arrangement for ongoing work. That covers payments, ordering, booking, and a system built around how your business runs. Either way the number comes once the plan is written, so it reflects the work in front of us rather than an hourly guess, and you have it before you commit to anything.',
+                'Anything past that is a fixed price for a defined project, or a monthly arrangement for ongoing work. That covers payments, ordering, booking, and a system built around how your business runs. Either way the number comes once the plan is written, so you have it before you commit to anything.',
             ],
             'link' => ['href' => '/zero-to-one/', 'label' => 'How Zero to One works'],
         ],
@@ -156,7 +156,7 @@ return [
             'q' => 'How long does it take?',
             'services' => 2,
             'a' => [
-                'Most projects run two to six weeks from the plan being agreed to something your customers can use. Bigger builds take longer, and I\'ll say so in the plan instead of discovering it halfway through.',
+                'Most projects run two to six weeks, from agreeing the plan to something your customers can use. Bigger builds take longer. I\'ll tell you that in the plan.',
             ],
         ],
         [
@@ -164,7 +164,7 @@ return [
             'q' => 'Why is Zero to One about a week when other work takes months?',
             'a' => [
                 'Because it\'s the same defined list every time, with one round of changes: a website, the words, the domain and hosting, and your Google listing. The narrow scope is what makes a week possible. Nothing is being rushed to fit it.',
-                'The moment a business needs online ordering or a booking system, it\'s a different job with a different number, and I\'ll tell you that instead of squeezing it in.',
+                'The moment a business needs online ordering or a booking system, it\'s a different job with a different number. I won\'t squeeze it in.',
             ],
             'link' => ['href' => '/zero-to-one/', 'label' => 'What is and is not included'],
         ],
@@ -175,7 +175,7 @@ return [
             'q' => 'What do you actually build?',
             'a' => [
                 'Web applications that work as well on a phone as on a laptop. I build both halves: what your customers see, and the system running behind it. There\'s no seam between them and nobody to coordinate with.',
-                'Where a client already has a designer or a front-end team, I take the half they can\'t do and stay out of the way of the half they can. That\'s usually the cheaper arrangement for them.',
+                'Where a client already has a designer or a front-end team, I take the half they can\'t do. That\'s usually the cheaper arrangement for them.',
             ],
             'link' => ['href' => '/work/', 'label' => 'Both projects ran that way'],
         ],
@@ -199,7 +199,7 @@ return [
             'q' => 'What is not included in Zero to One?',
             'a' => [
                 'A visual identity invented from scratch. The site is built for your business, but the look isn\'t designed from nothing. That\'s a separate job at a separate price. Logos, branding and photography aren\'t part of it either.',
-                'Payments, online ordering, booking systems and customer logins are all proper work rather than a box to tick, so they\'re quoted separately.',
+                'Payments, online ordering, booking systems and customer logins are all real work, so they\'re quoted separately.',
             ],
             'link' => ['href' => '/zero-to-one/', 'label' => 'The full list'],
         ],
@@ -209,7 +209,7 @@ return [
             'group' => 'What you own',
             'q' => 'Do I own what you build?',
             'a' => [
-                'All of it, from the first day. The code lives in your repository, it runs on your hosting account, and the domain stays registered to you. I work inside your accounts rather than mine, so there\'s nothing to prise loose at the end and nothing of yours sitting in my name.',
+                'All of it, from the first day. The code lives in your repository, it runs on your hosting account, and the domain stays registered to you. I work inside your accounts, so at the end there\'s nothing to pry loose and nothing of yours sitting in my name.',
             ],
         ],
         [
@@ -226,8 +226,8 @@ return [
             'group' => 'Working together',
             'q' => 'How do we work together?',
             'a' => [
-                'Remotely, and I\'ve worked this way for most of my career by choice, not by accident. My clients are across Europe and North America, and I arrange my day around whichever of those you\'re in, so there are hours every day when you can reach me directly instead of taking a queue position.',
-                'Most people settle into a short call once a week plus email in between. If you\'d rather have more or less than that, say so and we\'ll do that instead.',
+                'Remotely. I\'ve worked this way for most of my career and I\'m good at it. My clients are across Europe and North America, and I arrange my day around whichever of those you\'re in, so there are hours every day when you can reach me directly.',
+                'Most people settle into a short call once a week plus email in between. If you\'d rather have more or less than that, say so.',
             ],
         ],
         [
@@ -235,9 +235,9 @@ return [
             'q' => 'What happens if you are unavailable?',
             'services' => 4,
             'a' => [
-                'I\'m one person, so let me answer that properly instead of waving it away. There\'s no second developer waiting in the wings.',
+                'I\'m one person. There\'s no second developer waiting in the wings, and it\'s a fair thing to worry about.',
                 'What there is: you own every account and every line of code from day one, and I write things down as I go. That means a setup another developer can run, tests that say whether something is broken, and a walkthrough at handover. If I vanished tomorrow you wouldn\'t be locked out of anything, and someone competent could carry on from what\'s written.',
-                'That\'s a smaller risk than being unable to reach the agency holding your source code. It isn\'t zero, and you should hear it from me rather than find it out later.',
+                'That\'s a smaller risk than being unable to reach the agency holding your source code. It isn\'t zero, and I\'d rather say it out loud.',
             ],
         ],
         [
@@ -245,7 +245,7 @@ return [
             'q' => 'Should I hire you or an agency?',
             'a' => [
                 'Sometimes an agency. If the job needs several disciplines at once, has a deadline you can\'t move, or is large enough that coordinating it is a job in itself, buy the coordination.',
-                'If it\'s one system that has to be right and stay right, the distance between you and the person building it is the thing worth protecting. I\'ve written the comparison out in full, including the parts that don\'t favour me.',
+                'If it\'s one system that has to be right and stay right, the distance between you and the person building it is the thing worth protecting. I\'ve written the comparison out in full, including the parts that don\'t favor me.',
             ],
             'link' => ['href' => '/blog/agency-or-one-independent-engineer/', 'label' => 'The full comparison'],
         ],

--- a/source/_assets/css/components.css
+++ b/source/_assets/css/components.css
@@ -689,7 +689,7 @@ a.card:hover .card__title {
  * The section being read. --heading rather than the accent: nine entries with
  * one always lit would put a permanent spot of blue in the margin, and this is
  * a position indicator rather than a link worth clicking. The weight carries
- * it as much as the colour does, so it survives being looked at sideways.
+ * it as much as the color does, so it survives being looked at sideways.
  */
 .contents__list a.is-current {
     color: var(--heading);
@@ -2008,7 +2008,7 @@ textarea.field__input {
 
 /*
  * The call to action under the list. The section heading above the list is
- * centred, therefore this row is too.
+ * centered, therefore this row is too.
  */
 .biz-list__more {
     margin-top: var(--space-lg);
@@ -2146,8 +2146,8 @@ textarea.field__input {
 }
 
 /*
- * The link out to the full set. Centred under the list, which is itself
- * centred in the shell, so the two share an axis. Distinct from .faq__link,
+ * The link out to the full set. Centered under the list, which is itself
+ * centered in the shell, so the two share an axis. Distinct from .faq__link,
  * which sits inside an answer and reads from the left with the prose.
  */
 .faq__more {
@@ -2155,7 +2155,7 @@ textarea.field__input {
     text-align: center;
 }
 
-/* The section heading above this link is centred, therefore the link is too. */
+/* The section heading above this link is centered, therefore the link is too. */
 .work__more {
     margin-top: var(--space-lg);
     margin-bottom: 0;

--- a/source/_assets/css/layout.css
+++ b/source/_assets/css/layout.css
@@ -370,7 +370,7 @@
      * soon as it is open or stuck. A filtered ancestor becomes the containing
      * block for its fixed-position descendants, so `inset: <header> 0 0`
      * resolved against the 4rem header rather than the viewport and the panel
-     * collapsed to 108px — nothing to see, in every browser that honours
+     * collapsed to 108px — nothing to see, in every browser that honors
      * backdrop-filter. Positioning against the header deliberately is stable
      * either way: the header is full-width and pinned to the top, so
      * top:100% / left:0 / right:0 is exactly the viewport below it.

--- a/source/_assets/css/tokens.css
+++ b/source/_assets/css/tokens.css
@@ -110,7 +110,7 @@
        value measures 1.66, which is above the light theme rather than below it.
 
        The other end is worth knowing before reaching for it. 1.00 is the dot
-       being the background colour exactly, and much under 1.10 the field stops
+       being the background color exactly, and much under 1.10 the field stops
        surviving cheap panels and daylight — missing for a good share of
        visitors rather than subtle for them. If it ever needs to be quieter
        than that, drop the field in dark mode instead of painting something

--- a/source/_assets/js/main.js
+++ b/source/_assets/js/main.js
@@ -357,7 +357,7 @@ function initCopyButtons() {
  * which heading was the last one to pass the top of the viewport.
  *
  * Enhancement only. Without it the links still jump, and every entry simply
- * stays the colour it already was.
+ * stays the color it already was.
  */
 function initContents() {
     const rail = document.querySelector('.post-toc');
@@ -576,7 +576,7 @@ function initContactForm() {
                  * page views and nothing else, which cannot answer the one
                  * question worth asking: which page produces enquiries.
                  *
-                 * `generate_lead` is the recognised GA4 event name, so it lands
+                 * `generate_lead` is the recognized GA4 event name, so it lands
                  * in the reports that already exist rather than needing a
                  * custom definition. Fired only on a confirmed success, never
                  * on submit — otherwise a bounced request counts as a lead.

--- a/source/_components/dot-grid.blade.php
+++ b/source/_components/dot-grid.blade.php
@@ -10,9 +10,9 @@
     browser scales a grid of this density, a moiré pattern occurs.
 
     Parameters:
-      $spacing — pixels between dot centres              (default 24)
+      $spacing — pixels between dot centers              (default 24)
       $dot     — dot radius in pixels                    (default 1)
-      $centre  — vertical position of the clear area     (default 45)
+      $center  — vertical position of the clear area     (default 45)
       $clear   — radius of the clear area, per cent      (default 40)
       $peak    — position of full strength, per cent     (default 74)
       $tail    — start of the vertical fade, per cent    (default 100, off)
@@ -35,7 +35,7 @@
 @php
     $spacing = $spacing ?? 24;
     $dot = $dot ?? 1;
-    $centre = $centre ?? 45;
+    $center = $center ?? 45;
     $clear = $clear ?? 40;
     $peak = $peak ?? 74;
     $tail = $tail ?? 100;
@@ -44,7 +44,7 @@
 
     // A page can contain two dot grids. If two SVG ids are the same, the second
     // grid uses the pattern of the first grid, and no error occurs.
-    $id = 'dg' . substr(md5($spacing . '-' . $dot . '-' . $centre . '-' . uniqid('', true)), 0, 8);
+    $id = 'dg' . substr(md5($spacing . '-' . $dot . '-' . $center . '-' . uniqid('', true)), 0, 8);
 @endphp
 
 {{-- Do not add `width` or `height` attributes. They set the CSS width and
@@ -59,7 +59,7 @@
             <circle cx="{{ $dot }}" cy="{{ $dot }}" r="{{ $dot }}" fill="currentColor" />
         </pattern>
 
-        <radialGradient id="{{ $id }}-fade" cx="50%" cy="{{ $centre }}%" r="72%">
+        <radialGradient id="{{ $id }}-fade" cx="50%" cy="{{ $center }}%" r="72%">
             <stop offset="0%" stop-color="#fff" stop-opacity="0" />
             <stop offset="{{ $clear }}%" stop-color="#fff" stop-opacity="0" />
             <stop offset="{{ $peak }}%" stop-color="#fff" stop-opacity="1" />

--- a/source/_components/faq-item.blade.php
+++ b/source/_components/faq-item.blade.php
@@ -2,7 +2,7 @@
     One question.
 
     Keep the <details> element. Do not use a div with a click handler. The
-    native element gives the keyboard behaviour, the correct role and the
+    native element gives the keyboard behavior, the correct role and the
     expanded state to a screen reader. It also operates without JavaScript. CSS
     adds the animation, therefore a browser without the animation still opens
     and closes the item.

--- a/source/_components/icon.blade.php
+++ b/source/_components/icon.blade.php
@@ -1,7 +1,7 @@
 @php
     /*
      * Inline SVG icons. Each icon uses `currentColor`, therefore an icon in a
-     * link or a button gets the correct colour in the two themes.
+     * link or a button gets the correct color in the two themes.
      *
      * Usage: @include('_components.icon', ['name' => 'arrow-right'])
      *

--- a/source/_components/pixel-mark.blade.php
+++ b/source/_components/pixel-mark.blade.php
@@ -41,7 +41,7 @@
 @if ($shapes)
     {{-- Keep `shape-rendering="crispEdges"`. Without it, the browser
          antialiases the edges of the rects at fractional scales, and each pixel
-         gets a soft grey edge. --}}
+         gets a soft gray edge. --}}
     <svg class="pixel-mark {{ $class ?? '' }}" viewBox="0 0 {{ $width }} {{ $height }}"
         role="img" aria-label="{{ $label ?? 'pixel mark' }}" shape-rendering="crispEdges"
         fill="currentColor" focusable="false">

--- a/source/_components/testimonials.blade.php
+++ b/source/_components/testimonials.blade.php
@@ -10,7 +10,7 @@
       $band    — draw the section on the raised surface  (default true)
 
     Set `$band` to false when the section above this one is already a band. Two
-    bands together make one block of colour with no edge between them.
+    bands together make one block of color with no edge between them.
 --}}
 @php
     $quotes = collect($page->testimonials ?? []);

--- a/source/_includes/header.blade.php
+++ b/source/_includes/header.blade.php
@@ -38,7 +38,7 @@
                  current theme. The button is thus correct before the script
                  runs. --}}
             <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
-                <span class="visually-hidden">Toggle colour theme</span>
+                <span class="visually-hidden">Toggle color theme</span>
                 @include('_components.icon', ['name' => 'sun', 'class' => 'theme-toggle__icon theme-toggle__icon--sun'])
                 @include('_components.icon', ['name' => 'moon', 'class' => 'theme-toggle__icon theme-toggle__icon--moon'])
             </button>

--- a/source/_layouts/main.blade.php
+++ b/source/_layouts/main.blade.php
@@ -49,7 +49,7 @@
     <title>{{ $title }}</title>
     {{-- Do not add a `theme-color` meta tag. It can use only
          `prefers-color-scheme`. This site takes its theme from an attribute
-         that the visitor can change. The address bar then shows a colour that
+         that the visitor can change. The address bar then shows a color that
          disagrees with the page. `color-scheme` in tokens.css gives the browser
          the necessary data. --}}
     <meta name="robots" content="{{ $page->getRobotsStatus() }}">
@@ -116,7 +116,7 @@
         href="{{ $page->baseUrl }}/feed.xml">
     {{-- The .ico comes first, for a browser that reads no further. A browser
          that supports an SVG icon takes the SVG, which stays sharp at each size
-         and follows the colour scheme of the reader. --}}
+         and follows the color scheme of the reader. --}}
     <link rel="icon" href="{{ $favicon }}" sizes="16x16 32x32 48x48">
     {{-- A plain path. `viteStaticCopy` copies source/_assets/images verbatim,
          therefore the file has no manifest key and `vite()` throws on it. --}}

--- a/source/_posts/agency-or-one-independent-engineer.md
+++ b/source/_posts/agency-or-one-independent-engineer.md
@@ -243,8 +243,8 @@ if I'm unavailable, how the work runs, and what I won't take on.
 
 ## The two columns, side by side
 
-Everything above, in one place. Some of these rows favour an agency and some
-favour me; that's the point.
+Everything above, in one place. Some of these rows favor an agency and some
+favor me; that's the point.
 
 | | An agency | One independent engineer |
 | --- | --- | --- |

--- a/source/faq.blade.php
+++ b/source/faq.blade.php
@@ -15,7 +15,7 @@ title: Questions
         <h1>Questions.</h1>
 
         <p class="lead prose">Everything people ask me before they commit to anything: money, timing, ownership, and
-            the parts that are a risk rather than a selling point. If yours isn't here, ask it and I'll add it.</p>
+            the risks. If yours isn't here, ask it and I'll add it.</p>
     </div>
 
     <section class="shell section">
@@ -25,7 +25,7 @@ title: Questions
     <section class="shell section" id="contact">
         <div class="callout">
             <h2>Still not answered?</h2>
-            <p>Ask it directly. You'll get a straight answer within a day, including the times the answer is that I'm
+            <p>Ask it directly. You'll get a straight answer within a day, even when the answer is that I'm
                 not the right person for the job.</p>
 
             @include('_components.contact-form')

--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -20,7 +20,7 @@
          the shell is already full width. --}}
     <div class="hero-field">
         @include('_components.dot-grid', [
-            'centre' => 42,
+            'center' => 42,
             'clear' => 22,
             'peak' => 52,
             'tail' => 42,
@@ -138,7 +138,7 @@
     </section>
 
     {{-- No band. The section above this one is a band, and two together make
-         one block of colour with no edge between them. --}}
+         one block of color with no edge between them. --}}
     @include('_components.testimonials', ['band' => false])
 
     <section class="shell section" id="contact">

--- a/source/zero-to-one.blade.php
+++ b/source/zero-to-one.blade.php
@@ -86,7 +86,7 @@ title: Zero to One
                 $included = [
                     [
                         'title' => 'A website, with the pages you need',
-                        'body' => 'Built for your business, in your colours and with your photographs. It works properly on a phone, because that\'s where most of your customers will see it.',
+                        'body' => 'Built for your business, in your colors and with your photographs. It works properly on a phone, because that\'s where most of your customers will see it.',
                     ],
                     [
                         'title' => 'I write the words',

--- a/worker/README.md
+++ b/worker/README.md
@@ -142,7 +142,7 @@ npx wrangler d1 execute hesamrad-enquiries --remote \
 ```
 
 A real submission should produce: a row in D1, an email to `NOTIFY_TO` whose
-**reply** goes to the sender, a Telegram push, and an acknowledgement in the
+**reply** goes to the sender, a Telegram push, and an acknowledgment in the
 sender's inbox.
 
 ## Local development

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -272,7 +272,7 @@ function autoReply(enquiry, env) {
             to: enquiry.email,
             reply_to: env.NOTIFY_TO,
             subject: 'Thanks — I got your message',
-            // Plain text on purpose. A one-paragraph acknowledgement rendered
+            // Plain text on purpose. A one-paragraph acknowledgment rendered
             // as a marketing template is how a real reply gets filed as spam.
             text: [
                 `Hi ${enquiry.name.split(' ')[0] || 'there'},`,


### PR DESCRIPTION
Two changes, one commit each.

## American spelling site-wide

Replaced British spellings everywhere they appeared in page copy, blog copy, code comments, docs and CSS: `colour`, `centred`, `honours`, `grey`, `behaviour`, `favour`, `recognised`, `acknowledgement`, `licence`.

Renamed the `dot-grid` component prop `$centre` to `$center` and the `build_mark.py` constant `CENTRE` to `CENTER`, along with their call sites.

**Deliberately left alone:**

- The D1 table `enquiries`, the database name `hesamrad-enquiries`, and the `enquiry` variables in `worker/`. Renaming the table needs a migration on a live database holding real leads, and none of it is visitor facing. The prose in `worker/README.md` and the root `README.md` keeps `enquiry` too, so the docs match the table they describe.
- `@img/colour` in `worker/package-lock.json`. Third-party package name.

## FAQ answers

Most answers closed on the same rhetorical move: a statement, then the bad alternative it is not.

> "...so you know what it costs before you commit **instead of watching a meter run**."
> "...I've worked this way for most of my career **by choice, not by accident**."
> "It isn't zero, and you should hear it from me **rather than find it out later**."

Fifteen of twenty-four answers did it. One or two reads as voice; fifteen reads as a template, and it is one of the stronger tells of machine-written copy.

Removed the ending from ten answers, plus the page lead and the closing callout. Kept it in the three places where the contrast genuinely is the answer to the question: hourly billing, what I will not take on, and the agency comparison.

Prices, links, question text, group order, the `services` subset and the `FAQPage` schema are all unchanged.

## Verification

- `npm run build` passes.
- `/faq/` renders all 20 questions in their groups, with "What does it cost?" open by default.
- `/services/` still shows its four-question subset in the right order.
- `FAQPage` JSON-LD parses, 20 entries, answers reflect the new copy.
- Hero dot grid renders with `cy="42%"`, so the `$center` rename is wired through.
- No console errors.
- Full sweep of the built HTML finds no British spellings left.