### PR TITLE
Close a case study with the client review

### DIFF
--- a/source/_assets/css/components.css
+++ b/source/_assets/css/components.css
@@ -1357,21 +1357,125 @@ a.card:hover .card__title {
     border-top: 0;
 }
 
-.study__quote {
+/*
+ * The client review that closes a case study.
+ *
+ * The recommendation cards elsewhere sit in boxes, because they arrive in sets
+ * and the boxes tell one from the next. This is one review from the person who
+ * paid for the work, and it is the last thing on the page, so it gets no box
+ * and a larger size. The rule above it is the only edge it needs.
+ *
+ * On a wide screen the label and the person share a 12rem rail and the review
+ * runs beside them, which is the arrangement the recommendation cards use.
+ * Below 900px the three stack in reading order: label, review, person.
+ */
+.review {
     margin: var(--space-xl) 0 0;
-    padding: var(--space-md) 0 var(--space-md) var(--space-lg);
-    border-left: 2px solid var(--accent);
-    color: var(--heading);
-    font-size: var(--text-lg);
-    line-height: var(--leading-lede);
+    padding: var(--space-lg) 0 0;
+    border-top: var(--hairline) solid var(--line);
 }
 
-.study__quote cite {
-    display: block;
-    margin-top: var(--space-xs);
+@media (min-width: 900px) {
+    .review {
+        display: grid;
+        grid-template-columns: 12rem minmax(0, 1fr);
+        column-gap: var(--space-lg);
+    }
+
+    .review__label {
+        grid-column: 1;
+        grid-row: 1;
+    }
+
+    /* The review spans both rows, therefore it sets the height of the block and
+       the rail holds the label and the person against it. */
+    .review__quote {
+        grid-column: 2;
+        grid-row: 1 / span 2;
+    }
+
+    .review__author {
+        grid-column: 1;
+        grid-row: 2;
+        align-self: start;
+    }
+}
+
+.review__label {
+    margin: 0 0 var(--space-sm);
     color: var(--text-dim);
-    font-size: var(--text-sm);
-    font-style: normal;
+    font-size: var(--text-xs);
+    font-weight: 500;
+    line-height: var(--leading-body);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+@media (min-width: 900px) {
+    .review__label {
+        /* Optical alignment. The label is small text next to large text, and
+           the two baselines only agree with this nudge. */
+        margin-bottom: 0;
+        padding-top: 0.6rem;
+    }
+}
+
+.review__quote {
+    max-width: 46ch;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    color: var(--heading);
+    font-size: var(--text-xl);
+    line-height: var(--leading-lede);
+    letter-spacing: var(--tracking-tight);
+
+    /* At this size a one-word last line is visible from across the room. */
+    text-wrap: pretty;
+}
+
+.review__quote p {
+    margin: 0;
+}
+
+/* Hanging punctuation. The opening mark sits in the margin, therefore the
+   first line of the review starts on the same left edge as the lines under it.
+   A quotation mark inside the column pushes the first line right and the edge
+   reads as broken. */
+.review__quote p::before {
+    content: '\201C';
+    margin-inline-start: -0.42em;
+}
+
+.review__quote p::after {
+    content: '\201D';
+}
+
+.review__author {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    margin-top: var(--space-md);
+}
+
+@media (min-width: 900px) {
+    /* In the rail the person reads as a byline: the chip above the name, under
+       a rule that separates them from the label. The rule is short, because it
+       is the width of the rail and not of the page. */
+    .review__author {
+        flex-direction: column;
+        align-items: flex-start;
+        padding-top: var(--space-md);
+        border-top: var(--hairline) solid var(--line);
+    }
+}
+
+/* Quieter than the name and the role above it. The date qualifies the review.
+   It does not identify the person. */
+.review__date {
+    margin-top: 0.3rem;
+    color: var(--text-faint);
+    font-size: var(--text-xs);
 }
 
 .study__facts {

--- a/source/_caseStudies/broker-monitoring.md
+++ b/source/_caseStudies/broker-monitoring.md
@@ -46,7 +46,7 @@ timeline:
     - phase: 'Final months'
       detail: 'Thresholds, hardening, and handover to the team who run it.'
 results: []
-quote: null
+review: null
 differently: 'I started building before the measures were pinned down as tightly as they needed to be, assuming the details would settle as we went. They did settle, but some of them settled differently to how I''d built for, and I rewrote work that a longer conversation at the start would have got right the first time. On a system whose entire value is the precision of its definitions, the specification was the wrong place to move quickly.'
 cover:
     src: /assets/build/images/broker-monitoring.jpg

--- a/source/_caseStudies/top-menu.md
+++ b/source/_caseStudies/top-menu.md
@@ -56,7 +56,13 @@ results:
       caption: 'quicker to load for customers'
     - figure: '~1 min'
       caption: 'to release a change, from about an hour'
-quote: null
+review:
+    quote: 'After several disappointing experiences with other agencies, I met Hesam in another attempt to work on my idea. He designed the entire system architecture from the ground up and built a robust, scalable backend that powered all our front-end applications seamlessly. After five years of hard work, he turned my concept into the city’s #1 best-selling menu application.'
+    name: 'Mahdi Rasaei'
+    role: 'Founder, Top Menu'
+    # A year, a YYYY-MM, or a YYYY-MM-DD. The value goes in the `datetime`
+    # attribute, therefore it must stay in one of those three shapes.
+    date: '2025'
 differently: 'I built the venue dashboard before the platform dashboard, which meant that for the first couple of years every new venue came through me. It felt like the right order, since it was the thing customers touch first, but it made me the bottleneck in someone else''s growth and I stayed that way longer than I should have. The administrative screens were the least interesting work in the project and would have been worth doing a year earlier than I did them.'
 cover:
     src: /assets/build/images/top-menu.jpg

--- a/source/_layouts/case-study.blade.php
+++ b/source/_layouts/case-study.blade.php
@@ -218,13 +218,6 @@
                     </section>
                 @endif
 
-                @if ($page->quote)
-                    <blockquote class="study__quote">
-                        <p>{{ $page->quote['text'] }}</p>
-                        <cite>{{ $page->quote['attribution'] }}</cite>
-                    </blockquote>
-                @endif
-
                 @if ($page->differently)
                     <section class="study__section">
                         <h2>What I would do differently</h2>
@@ -281,6 +274,84 @@
                 </div>
             </aside>
         </div>
+
+        {{-- The client review. A case study without a `review` in its front
+             matter renders nothing here, and the page ends at the body above.
+             The review closes the article rather than sitting inside the main
+             column, because it is the client answering everything the article
+             claims. --}}
+        @php
+            $review = $page->review;
+
+            $reviewInitials = collect(preg_split('/\s+/', trim($review['name'] ?? '')))
+                ->filter()
+                ->take(2)
+                ->map(fn ($part) => mb_strtoupper(mb_substr($part, 0, 1)))
+                ->implode('');
+        @endphp
+
+        @if ($review && ! empty($review['quote']))
+            {{-- The order here is the order a phone reads: the label, the
+                 review, then the person. On a wide screen the stylesheet moves
+                 the label and the person into a left rail beside the review.
+                 The <figure> keeps the review and the name tied together. --}}
+            <figure class="review">
+                <h2 class="review__label">What the client said</h2>
+
+                <blockquote class="review__quote">
+                    <p>{{ $review['quote'] }}</p>
+                </blockquote>
+
+                <figcaption class="review__author">
+                    {{-- The avatar and name classes come from the
+                         recommendation cards. The chip is the same one, so a
+                         person is drawn the same way everywhere. --}}
+                    <span class="quote__avatar" aria-hidden="true">
+                        {{ $reviewInitials }}
+                        @if (!empty($review['avatar']))
+                            <img class="quote__photo" src="{{ $review['avatar'] }}" alt=""
+                                loading="lazy" decoding="async" width="44" height="44" data-avatar>
+                        @endif
+                    </span>
+
+                    <span class="quote__who">
+                        <span class="quote__name">
+                            @if (!empty($review['url']))
+                                <a href="{{ $review['url'] }}" target="_blank" rel="noopener noreferrer">{{ $review['name'] }}</a>
+                            @else
+                                {{ $review['name'] }}
+                            @endif
+                        </span>
+
+                        @if (!empty($review['role']))
+                            <span class="quote__role">{{ $review['role'] }}</span>
+                        @endif
+
+                        {{-- The date tells the reader how old the review is. A
+                             review of work that finished years ago and a review
+                             written last month are different evidence. --}}
+                        @if (!empty($review['date']))
+                            @php
+                                /*
+                                 * `datetime` takes a year, a YYYY-MM, or a
+                                 * YYYY-MM-DD. The reader gets a month name
+                                 * where the front matter gives a month, and
+                                 * the bare year where it gives a year.
+                                 */
+                                $reviewDate = (string) $review['date'];
+                                $reviewDateText = match (substr_count($reviewDate, '-')) {
+                                    2 => date('j F Y', strtotime($reviewDate)),
+                                    1 => date('F Y', strtotime($reviewDate . '-01')),
+                                    default => $reviewDate,
+                                };
+                            @endphp
+
+                            <time class="review__date tabular" datetime="{{ $reviewDate }}">Written in {{ $reviewDateText }}</time>
+                        @endif
+                    </span>
+                </figcaption>
+            </figure>
+        @endif
     </article>
 
     @if ($next && $next->getPath() !== $page->getPath())


### PR DESCRIPTION
## What

Adds a client review to the end of a case study. A `review` key in the front matter renders it. A case study without the key renders nothing, so the broker study is unchanged.

The key takes `quote`, `name`, `role`, `date`, and optional `url` and `avatar`. The date accepts a year, a `YYYY-MM`, or a `YYYY-MM-DD`, and reads as "Written in 2025", "Written in March 2025", or "Written in 14 March 2025". It goes in a `datetime` attribute, so it must stay in one of those three shapes.

Top Menu gets the review Mahdi Rasaei wrote. Broker monitoring gets `review: null`.

## Why

A case study argues its own case from start to finish. The client saying it worked is different evidence, and the page had nowhere to put it. The date matters because a review of work that finished years ago and a review written last month are not the same evidence.

## Design

The recommendation cards on the other pages sit in boxes, because they arrive in sets and the boxes tell one from the next. This is one review and it closes the page, so it gets no box and a larger size.

On a wide screen the label and the person share a 12rem rail and the review runs beside them. Below 900px the three stack in reading order: label, review, person. The DOM is in that reading order and the grid reorders it, so the phone gets the review before the byline.

The rail width, the avatar chip and the name classes come from the recommendation cards, so a person is drawn the same way everywhere.

The one typographic detail worth pointing at: the opening quotation mark hangs in the margin, so the first line of the review starts on the same left edge as the lines under it.

## Removed

The `quote` front matter key and the `.study__quote` rule it used. Both case studies had it set to `null`, it rendered nowhere, and leaving a second quote mechanism beside this one is a trap for the next edit. Say the word if you want it back.

## Checked

Light and dark, desktop and mobile. Broker page confirmed to render nothing. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)