### PR TITLE
Scope a question to a page, and close every page with questions then contact

### DIFF
--- a/config.php
+++ b/config.php
@@ -24,7 +24,9 @@ $pricing = [
     'currency' => 'USD',
 ];
 
-$money = fn ($amount) => $pricing['symbol'] . number_format($amount);
+$money = fn($amount) => $pricing['symbol'] . number_format($amount);
+
+$bookingUrl = 'https://cal.com/hesamrad/30min';
 
 return [
     'baseUrl' => 'http://localhost:8000',
@@ -41,7 +43,7 @@ return [
     // The one source for the booking link. Every "Book a call" button reads it.
     // The page it opens belongs to cal.com, therefore each of those links is
     // external and opens in a new tab.
-    'bookingUrl' => 'https://cal.com/hesamrad/30min',
+    'bookingUrl' => $bookingUrl,
     // The default locale and language. A page can override them with `locale`
     // or `language` front matter. A post without front matter gets the
     // post-specific pair below. The RTL support stays available: a post can
@@ -118,6 +120,15 @@ return [
      * with a `page` key ignores it, because only /faq/ shows groups.
      *
      * `open => true` opens the question on load.
+     *
+     * `link` puts one link under the answer. `href` accepts a path on this site
+     * or a full URL, and a full URL opens in a new tab:
+     *
+     *     'link' => ['href' => '/services/', 'label' => 'How the work runs'],
+     *     'link' => ['href' => 'https://laravel.com', 'label' => 'Laravel'],
+     *
+     * Write a path with the leading slash and without the base URL. The
+     * component adds the base URL to a path and leaves a full URL alone.
      *
      * Each answer is an array of paragraphs. For an amount of money, read the
      * `pricing` values. Do not write a figure again.
@@ -246,30 +257,27 @@ return [
         // figure, and it belongs on that page. Do not answer cost here with a
         // number.
         [
-            'group' => 'How long it takes',
-            'q' => 'How long does it take?',
+            'q' => 'What services do I offer?',
             'page' => '/services/',
             'a' => [
-                'Most projects run two to six weeks, from agreeing the plan to something your customers can use. Bigger builds take longer. I\'ll tell you that in the plan.',
+                'Bespoke web application development. I build applications that live on the internet; no mobile or desktop application.',
             ],
         ],
         [
-            'group' => 'Before we start',
-            'q' => 'What if I do not know exactly what I want yet?',
+            'q' => 'How can I see some of your previous works?',
             'page' => '/services/',
             'a' => [
-                'That\'s the normal case, and it\'s what the first call is for. You don\'t need a specification written. You need to be able to describe what\'s wrong today and what you\'d want instead. Working out what that means in software is part of what you\'re paying me for.',
+                'It is natural to feel skeptical but it\'s only fair you see some of the things that I\'ve done.',
             ],
+            'link' => ['href' => '/work/', 'label' => 'Read a few case studies'],
         ],
         [
-            'group' => 'Working together',
-            'q' => 'What happens if you are unavailable?',
+            'q' => 'How do I contact you?',
             'page' => '/services/',
             'a' => [
-                'I\'m one person. There\'s no second developer waiting in the wings, and it\'s a fair thing to worry about.',
-                'What there is: you own every account and every line of code from day one, and I write things down as I go. That means a setup another developer can run, tests that say whether something is broken, and a walkthrough at handover. If I vanished tomorrow you wouldn\'t be locked out of anything, and someone competent could carry on from what\'s written.',
-                'That\'s a smaller risk than being unable to reach the agency holding your source code. It isn\'t zero, and I\'d rather say it out loud.',
+                'There is a form right below this section you can use to write me; or you can just book a quick 30 minutes call so we can talk face to face and hear about your idea.',
             ],
+            'link' => ['href' => $bookingUrl, 'label' => 'Book a call'],
         ],
 
         // ── On /zero-to-one/ only ────────────────────────────────────────

--- a/config.php
+++ b/config.php
@@ -144,8 +144,8 @@ return [
             'group' => 'Before we start',
             'q' => 'What do you need from me to get started?',
             'a' => [
-                'Half an hour on a call, and straight answers in it. For a Zero to One website that\'s the whole of your homework. I write the words from what you tell me, because sitting down to write a page about your own business is the step that stalls most websites for months.',
-                'For larger work you\'ll also need to be reachable for a short call each week. Nothing else is needed up front: no specification, no wireframes, no list of features.',
+                'Half an hour on a call, and straight answers in it. You don\'t need a specification, wireframes, or a list of features written before we talk.',
+                'For larger work you\'ll also need to be reachable for a short call each week. Nothing else is needed up front.',
             ],
         ],
 
@@ -160,28 +160,9 @@ return [
         ],
         [
             'group' => 'What it costs',
-            'q' => 'What does the monthly fee cover?',
+            'q' => 'Can I pay you monthly for ongoing work?',
             'a' => [
-                'On Zero to One, ' . $pricing['symbol'] . number_format($pricing['monthly']) . ' a month covers hosting, the domain renewal, security updates, backups, and small changes when you need them: new opening hours, a price change, a few new photos. Email me and it gets done.',
-                'On larger projects a monthly arrangement is optional, and it covers whatever we agree it covers, written down before it starts.',
-            ],
-        ],
-        [
-            'group' => 'What it costs',
-            'q' => 'Can I stop paying the monthly fee?',
-            'a' => [
-                'Then stop. There\'s no minimum term. The domain is registered to you, and I\'ll hand over everything so you or anyone else can pick it up. Nothing in the paperwork keeps you here.',
-            ],
-        ],
-
-        // ── How long it takes ────────────────────────────────────────────
-        [
-            'group' => 'How long it takes',
-            'q' => 'Why is Zero to One about a week when other work takes months?',
-            'page' => '/zero-to-one/',
-            'a' => [
-                'Because it\'s the same defined list every time, with one round of changes: a website, the words, the domain and hosting, and your Google listing. The narrow scope is what makes a week possible. Nothing is being rushed to fit it.',
-                'The moment a business needs online ordering or a booking system, it\'s a different job with a different number. I won\'t squeeze it in.',
+                'On a larger project a monthly arrangement is optional. It covers whatever we agree it covers, written down before it starts.',
             ],
         ],
 
@@ -208,15 +189,6 @@ return [
             'q' => 'What will you not take on?',
             'a' => [
                 'Brand and logo design, apps written natively for iPhone and Android (I build web apps that work properly on a phone instead), and anything where the plan is to skip testing to hit a date. I\'ll say so on the first call, not three weeks in.',
-            ],
-        ],
-        [
-            'group' => 'What I build',
-            'q' => 'What is not included in Zero to One?',
-            'page' => '/zero-to-one/',
-            'a' => [
-                'A visual identity invented from scratch. The site is built for your business, but the look isn\'t designed from nothing. That\'s a separate job at a separate price. Logos, branding and photography aren\'t part of it either.',
-                'Payments, online ordering, booking systems and customer logins are all real work, so they\'re quoted separately.',
             ],
         ],
 
@@ -266,20 +238,13 @@ return [
         ],
 
         // ── On /services/ only ───────────────────────────────────────────
-        // These four leave /faq/ and close the services page, in this order:
-        // money, then time, then scope, then the risk of one person. The
-        // `group` key is unused while `page` is set.
-        [
-            'group' => 'What it costs',
-            'q' => 'What does it cost?',
-            'page' => '/services/',
-            'open' => true,
-            'a' => [
-                'The cheapest way in is Zero to One: a fixed website for ' . $pricing['symbol'] . number_format($pricing['setup']) . ', plus ' . $pricing['symbol'] . number_format($pricing['monthly']) . ' a month to keep it running. For a lot of businesses that\'s the whole answer.',
-                'Anything past that is a fixed price for a defined project, or a monthly arrangement for ongoing work. That covers payments, ordering, booking, and a system built around how your business runs. Either way the number comes once the plan is written, so you have it before you commit to anything.',
-            ],
-            'link' => ['href' => '/zero-to-one/', 'label' => 'How Zero to One works'],
-        ],
+        // These leave /faq/ and close the services page, in this order: time,
+        // then scope, then the risk of one person. The `group` key is unused
+        // while `page` is set.
+        //
+        // Money is not here. Every figure the site publishes is a Zero to One
+        // figure, and it belongs on that page. Do not answer cost here with a
+        // number.
         [
             'group' => 'How long it takes',
             'q' => 'How long does it take?',
@@ -304,6 +269,58 @@ return [
                 'I\'m one person. There\'s no second developer waiting in the wings, and it\'s a fair thing to worry about.',
                 'What there is: you own every account and every line of code from day one, and I write things down as I go. That means a setup another developer can run, tests that say whether something is broken, and a walkthrough at handover. If I vanished tomorrow you wouldn\'t be locked out of anything, and someone competent could carry on from what\'s written.',
                 'That\'s a smaller risk than being unable to reach the agency holding your source code. It isn\'t zero, and I\'d rather say it out loud.',
+            ],
+        ],
+
+        // ── On /zero-to-one/ only ────────────────────────────────────────
+        // The campaign, and the only place on the site that states a price.
+        // Keep it that way: an answer here can name a figure, and an answer
+        // anywhere else cannot. When the campaign ends, this block and the
+        // page go together and no answer elsewhere needs a rewrite.
+        [
+            'q' => 'What does it cost?',
+            'page' => '/zero-to-one/',
+            'open' => true,
+            'a' => [
+                $money($pricing['setup']) . ' once to build it and put it live, then ' . $money($pricing['monthly']) . ' a month to keep it running. That is the whole of it, and it does not move once we have agreed the work.',
+                'Anything outside the list on this page is a different job with its own fixed price, and that number comes once the plan is written.',
+            ],
+        ],
+        [
+            'q' => 'What does the monthly fee cover?',
+            'page' => '/zero-to-one/',
+            'a' => [
+                $money($pricing['monthly']) . ' a month covers hosting, the domain renewal, security updates, backups, and small changes when you need them: new opening hours, a price change, a few new photos. Email me and it gets done.',
+            ],
+        ],
+        [
+            'q' => 'Can I stop paying the monthly fee?',
+            'page' => '/zero-to-one/',
+            'a' => [
+                'Then stop. There\'s no minimum term. The domain is registered to you, and I\'ll hand over everything so you or anyone else can pick it up. Nothing in the paperwork keeps you here.',
+            ],
+        ],
+        [
+            'q' => 'How much work is this for me?',
+            'page' => '/zero-to-one/',
+            'a' => [
+                'Half an hour on a call, and that\'s the whole of your homework. I write the words from what you tell me, because sitting down to write a page about your own business is the step that stalls most websites for months.',
+            ],
+        ],
+        [
+            'q' => 'Why is this about a week when other work takes months?',
+            'page' => '/zero-to-one/',
+            'a' => [
+                'Because it\'s the same defined list every time, with one round of changes: a website, the words, the domain and hosting, and your Google listing. The narrow scope is what makes a week possible. Nothing is being rushed to fit it.',
+                'The moment a business needs online ordering or a booking system, it\'s a different job with a different number. I won\'t squeeze it in.',
+            ],
+        ],
+        [
+            'q' => 'What is not included?',
+            'page' => '/zero-to-one/',
+            'a' => [
+                'A visual identity invented from scratch. The site is built for your business, but the look isn\'t designed from nothing. That\'s a separate job at a separate price. Logos, branding and photography aren\'t part of it either.',
+                'Payments, online ordering, booking systems and customer logins are all real work, so they\'re quoted separately.',
             ],
         ],
     ],

--- a/config.php
+++ b/config.php
@@ -67,28 +67,63 @@ return [
     'pricing' => $pricing,
 
     /*
+     * The contact block that closes a page.
+     *
+     * main.blade.php puts this block last on every page, below the questions.
+     * These two values are the wording it uses. A page writes its own pair in
+     * its front matter when the default does not fit:
+     *
+     *     contactHeading: 'Still not answered?'
+     *     contactIntro: 'Ask it directly...'
+     *
+     * A page that must not ask for contact sets `disableContact: true` instead.
+     * A blog post never gets the block, because a post closes with the link to
+     * the next post.
+     *
+     * Keep the heading an instruction and not a label. "Get in touch" states
+     * the obvious. "Tell me what you're trying to build." states what to write.
+     */
+    'contact' => [
+        'heading' => 'Tell me what you\'re trying to build.',
+        'intro' => 'A paragraph is enough. I\'ll tell you whether I\'m the right person for it, including the times I\'m not.',
+    ],
+
+    /*
      * All questions, in one place.
      *
-     * Two pages read this array. /faq/ shows all the questions and carries the
-     * FAQPage schema. /services/ shows a subset. Keep the questions here and
-     * not in a template, because the two pages must show the same answers.
+     * The key is `siteFaq` and not `faq`. A post declares its own questions
+     * with a `faq:` block in its front matter, and front matter wins over this
+     * file. A post therefore hid this whole array from itself, and no question
+     * here could ever reach a post. The two structures also differ: `a` is an
+     * array of paragraphs here and one string in a post. Do not rename this key
+     * back.
      *
-     * `services` sets the sort order on the services page. Omit it to keep a
-     * question off that page. `open => true` opens the question on load.
+     * `page` decides where a question appears, and one question appears on one
+     * page:
+     *
+     * - No `page` key: the question shows on /faq/ and nowhere else. Most
+     *   questions belong here.
+     * - `page => '/zero-to-one/'`: the question shows at the end of that page
+     *   and not on /faq/. Use it for a question that makes sense only next to
+     *   that page, and write the path as it appears in the address bar.
+     *
+     * Nothing else is needed to put a question on a page. main.blade.php asks
+     * every page for its questions, and a page with none gets no heading and no
+     * empty block. Do not add an include to a template.
+     *
+     * A page shows its questions in the order of this array, therefore move an
+     * entry to move it up or down the page.
+     *
+     * `group` sets the heading above a run of questions on /faq/. A question
+     * with a `page` key ignores it, because only /faq/ shows groups.
+     *
+     * `open => true` opens the question on load.
      *
      * Each answer is an array of paragraphs. For an amount of money, read the
      * `pricing` values. Do not write a figure again.
      */
-    'faq' => [
+    'siteFaq' => [
         // ── Before we start ──────────────────────────────────────────────
-        [
-            'group' => 'Before we start',
-            'q' => 'What if I do not know exactly what I want yet?',
-            'services' => 3,
-            'a' => [
-                'That\'s the normal case, and it\'s what the first call is for. You don\'t need a specification written. You need to be able to describe what\'s wrong today and what you\'d want instead. Working out what that means in software is part of what you\'re paying me for.',
-            ],
-        ],
         [
             'group' => 'Before we start',
             'q' => 'What happens on the first call?',
@@ -117,17 +152,6 @@ return [
         // ── What it costs ────────────────────────────────────────────────
         [
             'group' => 'What it costs',
-            'q' => 'What does it cost?',
-            'services' => 1,
-            'open' => true,
-            'a' => [
-                'The cheapest way in is Zero to One: a fixed website for ' . $pricing['symbol'] . number_format($pricing['setup']) . ', plus ' . $pricing['symbol'] . number_format($pricing['monthly']) . ' a month to keep it running. For a lot of businesses that\'s the whole answer.',
-                'Anything past that is a fixed price for a defined project, or a monthly arrangement for ongoing work. That covers payments, ordering, booking, and a system built around how your business runs. Either way the number comes once the plan is written, so you have it before you commit to anything.',
-            ],
-            'link' => ['href' => '/zero-to-one/', 'label' => 'How Zero to One works'],
-        ],
-        [
-            'group' => 'What it costs',
             'q' => 'Do you charge by the hour?',
             'a' => [
                 'No. You get a number for the work, quoted after the plan is written, so you know what it costs before you commit instead of watching a meter run.',
@@ -153,20 +177,12 @@ return [
         // ── How long it takes ────────────────────────────────────────────
         [
             'group' => 'How long it takes',
-            'q' => 'How long does it take?',
-            'services' => 2,
-            'a' => [
-                'Most projects run two to six weeks, from agreeing the plan to something your customers can use. Bigger builds take longer. I\'ll tell you that in the plan.',
-            ],
-        ],
-        [
-            'group' => 'How long it takes',
             'q' => 'Why is Zero to One about a week when other work takes months?',
+            'page' => '/zero-to-one/',
             'a' => [
                 'Because it\'s the same defined list every time, with one round of changes: a website, the words, the domain and hosting, and your Google listing. The narrow scope is what makes a week possible. Nothing is being rushed to fit it.',
                 'The moment a business needs online ordering or a booking system, it\'s a different job with a different number. I won\'t squeeze it in.',
             ],
-            'link' => ['href' => '/zero-to-one/', 'label' => 'What is and is not included'],
         ],
 
         // ── What I build ─────────────────────────────────────────────────
@@ -197,11 +213,11 @@ return [
         [
             'group' => 'What I build',
             'q' => 'What is not included in Zero to One?',
+            'page' => '/zero-to-one/',
             'a' => [
                 'A visual identity invented from scratch. The site is built for your business, but the look isn\'t designed from nothing. That\'s a separate job at a separate price. Logos, branding and photography aren\'t part of it either.',
                 'Payments, online ordering, booking systems and customer logins are all real work, so they\'re quoted separately.',
             ],
-            'link' => ['href' => '/zero-to-one/', 'label' => 'The full list'],
         ],
 
         // ── What you own ─────────────────────────────────────────────────
@@ -232,16 +248,6 @@ return [
         ],
         [
             'group' => 'Working together',
-            'q' => 'What happens if you are unavailable?',
-            'services' => 4,
-            'a' => [
-                'I\'m one person. There\'s no second developer waiting in the wings, and it\'s a fair thing to worry about.',
-                'What there is: you own every account and every line of code from day one, and I write things down as I go. That means a setup another developer can run, tests that say whether something is broken, and a walkthrough at handover. If I vanished tomorrow you wouldn\'t be locked out of anything, and someone competent could carry on from what\'s written.',
-                'That\'s a smaller risk than being unable to reach the agency holding your source code. It isn\'t zero, and I\'d rather say it out loud.',
-            ],
-        ],
-        [
-            'group' => 'Working together',
             'q' => 'Should I hire you or an agency?',
             'a' => [
                 'Sometimes an agency. If the job needs several disciplines at once, has a deadline you can\'t move, or is large enough that coordinating it is a job in itself, buy the coordination.',
@@ -256,6 +262,48 @@ return [
             'q' => 'What happens after it launches?',
             'a' => [
                 'There\'s an agreed period where anything I built that turns out to be broken gets fixed at no extra cost. After that, some people want a monthly arrangement for changes and monitoring, and some take it in-house. The documentation exists so that second option is genuinely open to you. Both are fine, and neither is assumed.',
+            ],
+        ],
+
+        // ── On /services/ only ───────────────────────────────────────────
+        // These four leave /faq/ and close the services page, in this order:
+        // money, then time, then scope, then the risk of one person. The
+        // `group` key is unused while `page` is set.
+        [
+            'group' => 'What it costs',
+            'q' => 'What does it cost?',
+            'page' => '/services/',
+            'open' => true,
+            'a' => [
+                'The cheapest way in is Zero to One: a fixed website for ' . $pricing['symbol'] . number_format($pricing['setup']) . ', plus ' . $pricing['symbol'] . number_format($pricing['monthly']) . ' a month to keep it running. For a lot of businesses that\'s the whole answer.',
+                'Anything past that is a fixed price for a defined project, or a monthly arrangement for ongoing work. That covers payments, ordering, booking, and a system built around how your business runs. Either way the number comes once the plan is written, so you have it before you commit to anything.',
+            ],
+            'link' => ['href' => '/zero-to-one/', 'label' => 'How Zero to One works'],
+        ],
+        [
+            'group' => 'How long it takes',
+            'q' => 'How long does it take?',
+            'page' => '/services/',
+            'a' => [
+                'Most projects run two to six weeks, from agreeing the plan to something your customers can use. Bigger builds take longer. I\'ll tell you that in the plan.',
+            ],
+        ],
+        [
+            'group' => 'Before we start',
+            'q' => 'What if I do not know exactly what I want yet?',
+            'page' => '/services/',
+            'a' => [
+                'That\'s the normal case, and it\'s what the first call is for. You don\'t need a specification written. You need to be able to describe what\'s wrong today and what you\'d want instead. Working out what that means in software is part of what you\'re paying me for.',
+            ],
+        ],
+        [
+            'group' => 'Working together',
+            'q' => 'What happens if you are unavailable?',
+            'page' => '/services/',
+            'a' => [
+                'I\'m one person. There\'s no second developer waiting in the wings, and it\'s a fair thing to worry about.',
+                'What there is: you own every account and every line of code from day one, and I write things down as I go. That means a setup another developer can run, tests that say whether something is broken, and a walkthrough at handover. If I vanished tomorrow you wouldn\'t be locked out of anything, and someone competent could carry on from what\'s written.',
+                'That\'s a smaller risk than being unable to reach the agency holding your source code. It isn\'t zero, and I\'d rather say it out loud.',
             ],
         ],
     ],

--- a/source/404.blade.php
+++ b/source/404.blade.php
@@ -3,6 +3,7 @@ title: Not Found!
 permalink: /404.html
 robots: noindex,follow
 disableCanonical: true
+disableContact: true
 ---
 
 @extends('_layouts.main')

--- a/source/_assets/css/components.css
+++ b/source/_assets/css/components.css
@@ -18,8 +18,20 @@
     color: var(--text-dim);
 }
 
+/*
+ * The cap keeps a page heading off the full width of the shell. It is not a
+ * character count. One ch is the width of the zero of the font, and this
+ * heading has weight 600 and negative tracking, so at the desktop size one ch
+ * is about 32px and 22ch is about 705px in a 1120px shell.
+ *
+ * 22ch holds every heading on the site on one line except the work page, at
+ * 25.6ch, which is written in two clauses and reads better in two lines. Before
+ * a heading of more than about 20 characters, measure it. Do not raise this
+ * value to hold one long heading: mark the break in the markup instead, the way
+ * the home page does.
+ */
 .page-head h1 {
-    max-width: 16ch;
+    max-width: 22ch;
     margin-bottom: var(--space-md);
     font-size: var(--text-3xl);
 }

--- a/source/_caseStudies/broker-monitoring.md
+++ b/source/_caseStudies/broker-monitoring.md
@@ -3,6 +3,8 @@ extends: _layouts.case-study
 section: content
 title: 'The metrics a broker could not buy'
 description: 'A monitoring layer that let a brokerage watch its traders on its own measures rather than the ones its trading platform happened to report.'
+contactHeading: 'Got something like this?'
+contactIntro: "Describe it in a paragraph. You will get an honest answer about whether I am the right person for it, including the times when I am not."
 published: true
 sample: false
 client: null

--- a/source/_caseStudies/top-menu.md
+++ b/source/_caseStudies/top-menu.md
@@ -3,6 +3,8 @@ extends: _layouts.case-study
 section: content
 title: 'A menu that changes without a print run'
 description: 'Top Menu: a digital menu and ordering platform for cafés and restaurants, built and run over five years as lead engineer.'
+contactHeading: 'Got something like this?'
+contactIntro: "Describe it in a paragraph. You will get an honest answer about whether I am the right person for it, including the times when I am not."
 published: true
 sample: false
 client: 'Mahdi Rasaei'

--- a/source/_components/contact-section.blade.php
+++ b/source/_components/contact-section.blade.php
@@ -1,0 +1,32 @@
+{{--
+    The contact block that closes a page.
+
+    main.blade.php includes this last, below the questions. Do not put a copy in
+    a page template. Two copies give a page two `id="contact"` anchors, and the
+    buttons that point at #contact then reach the first one.
+
+    A page opts out with `disableContact: true` in its front matter. A blog post
+    opts out on its own, because a post closes with the link to the next post,
+    and that link is the stronger action there.
+
+    The wording comes from the front matter of the page and falls back to the
+    `contact` pair in config.php. Read that comment before a change here.
+--}}
+@php
+    $showsContact = ! $page->disableContact && ! $page->isPost($page);
+    $contactHeading = $page->contactHeading ?: $page->contact['heading'];
+    $contactIntro = $page->contactIntro ?: $page->contact['intro'];
+@endphp
+
+@if ($showsContact)
+    {{-- Keep `id="contact"`. Every "Start a conversation" link on the site ends
+         in this fragment, and the footer link uses it on the home page. --}}
+    <section class="shell section" id="contact">
+        <div class="callout">
+            <h2>{{ $contactHeading }}</h2>
+            <p>{{ $contactIntro }}</p>
+
+            @include('_components.contact-form')
+        </div>
+    </section>
+@endif

--- a/source/_components/faq-item.blade.php
+++ b/source/_components/faq-item.blade.php
@@ -23,8 +23,26 @@
         @endforeach
 
         @if ($link = $question['link'] ?? null)
+            @php
+                /*
+                 * `href` accepts a path on this site ('/services/') or a full
+                 * URL ('https://laravel.com'). Add the base URL only to a path.
+                 * Without the test, a full URL joins to the host and gives
+                 * 'http://localhost:8000https://laravel.com'.
+                 *
+                 * The first test finds any scheme and a protocol-relative URL,
+                 * therefore mailto: and tel: also stay as written. The second
+                 * finds the subset that leaves the site, and only those links
+                 * open in a new tab.
+                 */
+                $hasScheme = (bool) preg_match('#^([a-z][a-z0-9+.-]*:|//)#i', $link['href']);
+                $isExternal = (bool) preg_match('#^(https?:)?//#i', $link['href']);
+                $href = $hasScheme ? $link['href'] : $page->baseUrl . $link['href'];
+            @endphp
+
             <p class="faq__link">
-                <a class="link-arrow" href="{{ $page->baseUrl . $link['href'] }}">
+                <a class="link-arrow" href="{{ $href }}"
+                    @if ($isExternal) target="_blank" rel="noopener noreferrer" @endif>
                     <span>{{ $link['label'] }}</span>
                     @include('_components.icon', ['name' => 'arrow-right'])
                 </a>

--- a/source/_components/faq-list.blade.php
+++ b/source/_components/faq-list.blade.php
@@ -1,13 +1,13 @@
 {{--
-    A list of questions as native disclosures. /faq/ and /services/ show the
-    same markup from the same data in config.php.
+    A list of questions as native disclosures. /faq/ and any page with its own
+    questions show the same markup from the same data in config.php.
 
-    Do not emit the FAQPage schema from this component. The caller must emit it,
-    because only one page can carry the schema. If two pages carry it, a search
-    engine accepts neither page as the FAQ.
+    Do not emit the FAQPage schema from this component. The caller emits it with
+    _components.faq-schema, and it passes the same rows it passed here. A caller
+    that shows a part of the array must not declare the whole array.
 
     Parameters:
-      $items   — rows from $page->faq
+      $items   — rows from $page->siteFaq
       $grouped — when true, show each `group` as a heading  (default false)
 --}}
 @php

--- a/source/_components/faq-schema.blade.php
+++ b/source/_components/faq-schema.blade.php
@@ -1,0 +1,33 @@
+{{--
+    The FAQPage node for one page.
+
+    Pass only the questions that the page shows. The data of a rich result must
+    agree with the text that the visitor reads. Do not pass the full array on a
+    page that shows a part of it.
+
+    More than one page carries this node, and that is correct here. Each page
+    declares a different set of questions, because a question belongs to one
+    page. Do not put the same set on two pages. Two pages with one identical set
+    compete with each other, and a search engine can then accept neither page.
+
+    `@id` holds the canonical URL of the page, therefore each node has its own
+    identifier.
+
+    Parameters:
+      $items — rows from $page->siteFaq
+--}}
+<script type="application/ld+json">
+    {!! json_encode([
+        '@context' => 'https://schema.org',
+        '@type' => 'FAQPage',
+        '@id' => $page->getCanonicalUrl() . '#faq',
+        'mainEntity' => collect($items)->map(fn ($question) => [
+            '@type' => 'Question',
+            'name' => $question['q'],
+            'acceptedAnswer' => [
+                '@type' => 'Answer',
+                'text' => html_entity_decode(strip_tags(implode(' ', collect($question['a'])->all())), ENT_QUOTES, 'UTF-8'),
+            ],
+        ])->all(),
+    ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT) !!}
+</script>

--- a/source/_components/faq-section.blade.php
+++ b/source/_components/faq-section.blade.php
@@ -36,7 +36,7 @@
 @if ($pageQuestions->isNotEmpty())
     <div class="shell section">
         <div class="section-head">
-            <h2>Questions.</h2>
+            <h2>Questions</h2>
         </div>
 
         @include('_components.faq-list', ['items' => $pageQuestions])

--- a/source/_components/faq-section.blade.php
+++ b/source/_components/faq-section.blade.php
@@ -1,0 +1,50 @@
+{{--
+    The questions that belong to the current page.
+
+    main.blade.php includes this after the body of every page. The component
+    reads the `page` key of each question in config.php and keeps the questions
+    whose value is the path of this page. A page with no such question gets no
+    markup: no heading, no empty container, no schema. Therefore a new block of
+    questions on a page needs a `page` key in config.php and no change to a
+    template.
+
+    /faq/ shows nothing from here. Its questions carry no `page` key, and that
+    page renders them itself, in groups, with its own schema.
+
+    The path comparison removes the leading and the trailing slash from both
+    values. `getPath()` adds a trailing slash only when `trailing_slash` is on
+    in the configuration, therefore a comparison of the raw values fails when
+    that setting changes. The home page gives an empty path, and '/' in the
+    configuration also becomes empty.
+--}}
+@php
+    $currentPath = trim($page->getPath(), '/');
+
+    $pageQuestions = collect($page->siteFaq)
+        ->filter(fn ($question) => isset($question['page']) && trim($question['page'], '/') === $currentPath)
+        ->values();
+
+    /*
+     * A post with a `faq:` block in its front matter already declares FAQPage,
+     * from post.blade.php, under the same `@id`. A second node here would give
+     * one address two FAQPage nodes with one identifier, and that is not valid
+     * data. The questions stay visible and this page adds no node.
+     */
+    $ownsSchema = ! $page->faq;
+@endphp
+
+@if ($pageQuestions->isNotEmpty())
+    <div class="shell section">
+        <div class="section-head">
+            <h2>Questions.</h2>
+        </div>
+
+        @include('_components.faq-list', ['items' => $pageQuestions])
+    </div>
+
+    @if ($ownsSchema)
+        @push('scripts')
+            @include('_components.faq-schema', ['items' => $pageQuestions])
+        @endpush
+    @endif
+@endif

--- a/source/_includes/structured-data.blade.php
+++ b/source/_includes/structured-data.blade.php
@@ -25,9 +25,13 @@
     /*
      * This node tells a search engine that the site is a service provider.
      *
-     * Add only a claim that the site also makes in its text. The price is the
-     * price on the Zero to One page. The area served is the area in the footer
-     * and in the FAQ.
+     * Add only a claim that the site also makes in its text. The area served is
+     * the area in the footer and in the FAQ.
+     *
+     * This node carries no price and names no campaign. It is on every page,
+     * and a price on /about/ or on a post is a price for a service that page
+     * does not describe. A page that states a price declares its own Offer.
+     * /zero-to-one/ is the one page that does.
      */
     $business = [
         '@type' => 'ProfessionalService',
@@ -47,19 +51,10 @@
         'hasOfferCatalog' => [
             '@type' => 'OfferCatalog',
             'name' => 'Software development services',
+            // Zero to One is not in this catalog. Its Offer carries a price, and
+            // the price belongs on the page that states it. zero-to-one.blade.php
+            // declares that Offer and points it back at this node.
             'itemListElement' => [
-                [
-                    '@type' => 'Offer',
-                    'itemOffered' => [
-                        '@type' => 'Service',
-                        'name' => 'Zero to One',
-                        'description' => 'A complete website for a business that has none: built, launched and looked after, at a fixed price.',
-                        'serviceType' => 'Website design and development',
-                        'url' => $page->baseUrl . '/zero-to-one/',
-                    ],
-                    'price' => (string) $page->pricing['setup'],
-                    'priceCurrency' => $page->pricing['currency'],
-                ],
                 [
                     '@type' => 'Offer',
                     'itemOffered' => [
@@ -69,9 +64,10 @@
                         'serviceType' => 'Custom software development',
                         'url' => $page->baseUrl . '/services/',
                     ],
-                    // This offer has no `price` key. The site does not publish
-                    // a price for custom work.
-                    'priceCurrency' => $page->pricing['currency'],
+                    // This offer states no money at all. The site publishes no
+                    // price for custom work, and a currency with no price says
+                    // nothing. Keeping it also made this file read `pricing`,
+                    // which exists for the campaign.
                 ],
             ],
         ],

--- a/source/_layouts/case-study.blade.php
+++ b/source/_layouts/case-study.blade.php
@@ -369,13 +369,4 @@
         </nav>
     @endif
 
-    <div class="shell section" id="contact">
-        <div class="callout">
-            <h2>Got something like this?</h2>
-            <p>Describe it in a paragraph. You will get an honest answer about whether I am the right person for it,
-                including the times when I am not.</p>
-
-            @include('_components.contact-form')
-        </div>
-    </div>
 @endsection

--- a/source/_layouts/main.blade.php
+++ b/source/_layouts/main.blade.php
@@ -156,6 +156,8 @@
          next Tab goes back into that nav. --}}
     <main id="main" class="page-main" tabindex="-1">
         @yield('body')
+        @include('_components.faq-section')
+        @include('_components.contact-section')
     </main>
 
     @include('_includes.footer')

--- a/source/_layouts/post.blade.php
+++ b/source/_layouts/post.blade.php
@@ -245,7 +245,12 @@
 
 {{-- A `faq:` block in the front matter makes a FAQPage node. The same
      questions and answers must also be visible in the body of the post. Google
-     gives this condition for the markup. --}}
+     gives this condition for the markup.
+
+     This `faq:` belongs to the post and has nothing to do with `siteFaq` in
+     config.php. `a` is one string here and an array of paragraphs there, and
+     this block writes no visible markup, because the post writes the questions
+     itself. Do not pass these rows to _components.faq-list. --}}
 @if ($page->faq)
     @push('scripts')
         <script type="application/ld+json">

--- a/source/about.blade.php
+++ b/source/about.blade.php
@@ -1,5 +1,6 @@
 ---
 title: About
+disableContact: true
 ---
 
 @extends('_layouts.main')

--- a/source/blog.blade.php
+++ b/source/blog.blade.php
@@ -1,5 +1,6 @@
 ---
 title: Blog
+disableContact: true
 ---
 
 @extends('_layouts.main')

--- a/source/faq.blade.php
+++ b/source/faq.blade.php
@@ -1,5 +1,7 @@
 ---
 title: Questions
+contactHeading: 'Still not answered?'
+contactIntro: "Ask it directly. You'll get a straight answer within a day, even when the answer is that I'm not the right person for the job."
 ---
 
 @extends('_layouts.main')
@@ -7,6 +9,18 @@ title: Questions
 @section('title', 'Questions')
 
 @section('description', 'What it costs, how long it takes, what you own at the end, and what happens if I\'m unavailable. Every question I get asked before somebody hires me.')
+
+@php
+    /*
+     * The questions with no `page` key. A question with a `page` key belongs to
+     * that page and shows there only, therefore this page must not repeat it.
+     * Without this filter the same question and the same FAQPage entry appear on
+     * two addresses.
+     */
+    $questions = collect($page->siteFaq)
+        ->reject(fn ($question) => isset($question['page']))
+        ->values();
+@endphp
 
 @section('body')
     <div class="shell section page-head">
@@ -19,38 +33,13 @@ title: Questions
     </div>
 
     <section class="shell section">
-        @include('_components.faq-list', ['items' => $page->faq, 'grouped' => true])
+        @include('_components.faq-list', ['items' => $questions, 'grouped' => true])
     </section>
 
-    <section class="shell section" id="contact">
-        <div class="callout">
-            <h2>Still not answered?</h2>
-            <p>Ask it directly. You'll get a straight answer within a day, even when the answer is that I'm
-                not the right person for the job.</p>
-
-            @include('_components.contact-form')
-        </div>
-    </section>
-
-    {{-- This page carries the FAQPage schema for the whole site. /services/
-         shows some of these questions again, but it does not declare the
-         schema. If two pages declare the schema, a search engine accepts
-         neither page. --}}
+    {{-- The schema holds the questions this page shows and no more. A page with
+         its own questions carries its own node, from the same component. Pass
+         `$questions` and not `$page->siteFaq`. --}}
     @push('scripts')
-        <script type="application/ld+json">
-            {!! json_encode([
-                '@context' => 'https://schema.org',
-                '@type' => 'FAQPage',
-                '@id' => $page->getCanonicalUrl() . '#faq',
-                'mainEntity' => collect($page->faq)->map(fn ($question) => [
-                    '@type' => 'Question',
-                    'name' => $question['q'],
-                    'acceptedAnswer' => [
-                        '@type' => 'Answer',
-                        'text' => html_entity_decode(strip_tags(implode(' ', collect($question['a'])->all())), ENT_QUOTES, 'UTF-8'),
-                    ],
-                ])->all(),
-            ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT) !!}
-        </script>
+        @include('_components.faq-schema', ['items' => $questions])
     @endpush
 @endsection

--- a/source/faq.blade.php
+++ b/source/faq.blade.php
@@ -26,7 +26,7 @@ contactIntro: "Ask it directly. You'll get a straight answer within a day, even 
     <div class="shell section page-head">
         @include('_components.breadcrumbs')
 
-        <h1>Questions.</h1>
+        <h1>Questions</h1>
 
         <p class="lead prose">Everything people ask me before they commit to anything: money, timing, ownership, and
             the risks. If yours isn't here, ask it and I'll add it.</p>

--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -140,14 +140,4 @@
     {{-- No band. The section above this one is a band, and two together make
          one block of color with no edge between them. --}}
     @include('_components.testimonials', ['band' => false])
-
-    <section class="shell section" id="contact">
-        <div class="callout">
-            <h2>Tell me what you're trying to build.</h2>
-            <p>A paragraph is enough. I'll tell you whether I'm the right person for it, including the times I'm
-                not.</p>
-
-            @include('_components.contact-form')
-        </div>
-    </section>
 @endsection

--- a/source/projects.blade.php
+++ b/source/projects.blade.php
@@ -1,5 +1,6 @@
 ---
 title: Open source
+disableContact: true
 ---
 
 @extends('_layouts.main')

--- a/source/services.blade.php
+++ b/source/services.blade.php
@@ -1,5 +1,7 @@
 ---
 title: Services
+contactHeading: 'Describe the problem in a paragraph.'
+contactIntro: "That's enough for me to tell you whether this is a week of work or a quarter, and whether I'm the right person for it."
 ---
 
 @extends('_layouts.main')
@@ -108,44 +110,10 @@ title: Services
         </div>
     </div>
 
-    <div class="shell section">
-        <div class="section-head">
-            <h2>The questions people ask.</h2>
-            <p>Money and time first, then the ones about risk. If what you need to know isn't here, it's a fair thing
-                to open with.</p>
-        </div>
-
-
-        {{-- This is the subset with a `services` key, sorted by its value.
-             /faq/ shows the same array in full. Do not add the FAQPage schema
-             to this page. Only /faq/ carries the schema. If two pages declare
-             the schema, a search engine accepts neither page. --}}
-        @include('_components.faq-list', [
-            'items' => collect($page->faq)
-                ->filter(fn ($q) => $q['services'] ?? false)
-                ->sortBy('services')
-                ->values(),
-        ])
-
-        {{-- Use this class and do not use .faq__link. .faq__link is the
-             left-aligned link inside an answer. --}}
-        <p class="faq__more">
-            <a class="link-arrow" href="{{ $page->baseUrl }}/faq/">
-                <span>The other sixteen questions</span>
-                @include('_components.icon', ['name' => 'arrow-right'])
-            </a>
-        </p>
-    </div>
+    {{-- The questions for this page are not here. main.blade.php puts them below
+         the body and above the contact block. To add one, put
+         `page => '/services/'` on a question in config.php. Do not add an include
+         here, and do not repeat a question that /faq/ already shows. --}}
 
     @include('_components.testimonials', ['limit' => 2])
-
-    <div class="shell section" id="contact">
-        <div class="callout">
-            <h2>Describe the problem in a paragraph.</h2>
-            <p>That's enough for me to tell you whether this is a week of work or a quarter, and whether I'm the right
-                person for it.</p>
-
-            @include('_components.contact-form')
-        </div>
-    </div>
 @endsection

--- a/source/services.blade.php
+++ b/source/services.blade.php
@@ -14,9 +14,10 @@ contactIntro: "That's enough for me to tell you whether this is a week of work o
     <div class="shell section page-head">
         @include('_components.breadcrumbs')
 
-        <h1>Work I take on.</h1>
-        <p class="lead prose">I build complete products, on my own: the part your customers use, the system behind it,
-            and everything needed to keep it running. Here's the kind of work I take, how it runs, and how to start.</p>
+        <h1>Bespoke web development</h1>
+        <p class="lead prose">Software built for one business: yours. The screens your customers use, the system
+            running behind them, and everything needed to keep it working. I build all of it myself, and I'm still
+            here when it needs changing.</p>
 
         <p class="mt-md"><span class="availability">Available for new projects</span></p>
     </div>

--- a/source/thank-you.blade.php
+++ b/source/thank-you.blade.php
@@ -1,6 +1,7 @@
 ---
 title: Thank you
 robots: noindex,follow
+disableContact: true
 ---
 @extends('_layouts.main')
 

--- a/source/work.blade.php
+++ b/source/work.blade.php
@@ -1,5 +1,7 @@
 ---
 title: Work
+contactHeading: "Tell me what you're trying to build."
+contactIntro: "A paragraph is enough. I'll tell you whether I've done something like it before, and whether I'm the right person for this one."
 ---
 
 @extends('_layouts.main')
@@ -58,13 +60,4 @@ title: Work
         @endif
     </div>
 
-    <div class="shell section" id="contact">
-        <div class="callout">
-            <h2>Tell me what you're trying to build.</h2>
-            <p>A paragraph is enough. I'll tell you whether I've done something like it before, and whether I'm the
-                right person for this one.</p>
-
-            @include('_components.contact-form')
-        </div>
-    </div>
 @endsection

--- a/source/zero-to-one.blade.php
+++ b/source/zero-to-one.blade.php
@@ -1,5 +1,7 @@
 ---
 title: Zero to One
+contactHeading: 'Tell me about the business.'
+contactIntro: "A couple of sentences is plenty: what you do and roughly where. I'll tell you whether Zero to One is right for you, and if it isn't, what would be."
 ---
 
 @extends('_layouts.main')
@@ -276,13 +278,4 @@ title: Zero to One
         @endif
     </section>
 
-    <section class="shell section" id="contact">
-        <div class="callout">
-            <h2>Tell me about the business.</h2>
-            <p>A couple of sentences is plenty: what you do and roughly where. I'll tell you whether Zero to One is
-                right for you, and if it isn't, what would be.</p>
-
-            @include('_components.contact-form')
-        </div>
-    </section>
 @endsection

--- a/source/zero-to-one.blade.php
+++ b/source/zero-to-one.blade.php
@@ -278,4 +278,36 @@ contactIntro: "A couple of sentences is plenty: what you do and roughly where. I
         @endif
     </section>
 
+    {{-- The Offer for the campaign, with the price, on the one page that states
+         the price. structured-data.blade.php runs on every page and therefore
+         carries no price and no campaign: a price on /about/ or on a post is a
+         price for a service that page does not describe.
+
+         `provider` points at the ProfessionalService node that the shared
+         include declares, so the two agree without repeating the business.
+
+         The figures come from `pricing` in config.php, which is also what the
+         price block above reads. A search engine and a reader thus cannot be
+         shown two different numbers. When the campaign ends, this block goes
+         with the page and no shared file needs a change. --}}
+    @push('scripts')
+        <script type="application/ld+json">
+            {!! json_encode([
+                '@context' => 'https://schema.org',
+                '@type' => 'Offer',
+                '@id' => $page->getCanonicalUrl() . '#offer',
+                'url' => $page->getCanonicalUrl(),
+                'price' => (string) $page->pricing['setup'],
+                'priceCurrency' => $page->pricing['currency'],
+                'provider' => ['@id' => $page->baseUrl . '/#business'],
+                'itemOffered' => [
+                    '@type' => 'Service',
+                    'name' => 'Zero to One',
+                    'description' => 'A complete website for a business that has none: built, launched and looked after, at a fixed price.',
+                    'serviceType' => 'Website design and development',
+                    'url' => $page->getCanonicalUrl(),
+                ],
+            ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT) !!}
+        </script>
+    @endpush
 @endsection


### PR DESCRIPTION
## What changed

A question in `config.php` can now name the page it belongs to, and the layout closes every page the same way: the questions for that page, then the contact block.

**Page-scoped questions.** `page => '/services/'` on a question puts it at the end of that page and takes it off `/faq/`. No `page` key means it stays on `/faq/`, which is where most belong. `main.blade.php` asks each page for its questions, so a page gains or loses a questions block from `config.php` alone. A page with no matching question renders nothing: no heading, no empty container, no schema.

**Contact in the layout.** The block moved out of the six pages that each held a copy. It is now last on every page, with the questions above it. Wording stays per page in front matter, with a default pair in `config.php`. `disableContact: true` opts a page out. Posts never get it, since a post closes with the link to the next post.

**One FAQPage node per page, matching what the page shows.** New `faq-schema` component. Previously `/faq/` declared the whole array while `/services/` repeated part of it visibly, putting the same question on two addresses.

## Two bugs found while testing

**`faq` key collision.** The site array is now `siteFaq`. A post declares its own questions in a `faq:` front matter block, front matter wins over `config.php`, so a post hid the entire site array from itself — no scoped question could ever reach a post. The structures differ too: `a` is an array of paragraphs in `config.php` and one string in a post, so `faq-list` would have iterated a string. Post front matter keeps `faq:`, untouched.

**Duplicate `@id`.** With the rename working, a post with a scoped question emitted two FAQPage nodes both claiming `canonicalUrl#faq`. `faq-section` now skips its schema when the page already declares one; questions stay visible, one node per URL.

## Content moved with the mechanism

- The four questions `/services/` used to repeat now belong to it, in the previous order: money, time, scope, risk.
- The two Zero to One questions now belong to `/zero-to-one/`.
- Both of those carried a link to the page they now sit on. Self-links removed.
- `/services/` lost its "The questions people ask." heading and its `/faq/` link. The footer links Questions on every page.

## Verified against build_production

| page | questions | schema entries | contact |
|---|---|---|---|
| `/services/` | 4 | 4 | after the questions |
| `/zero-to-one/` | 2 | 2 | after the questions |
| `/faq/` | 14 | 14 | last |
| `/`, `/work/`, `/work/top-menu/` | 0 | 0 | last |
| about, blog, projects, thank-you, 404 | 0 | 0 | none |
| blog post | 0 | 5 (its own) | none |

Also probed with a throwaway question that the block fires for `/`, `/work/`, `/work/top-menu/` and a blog post path, then reverted the probe. All six pages keep `id="contact"`, so the `#contact` links in the hero, footer, about page and post CTA still land.

## For the reviewer

Two content problems the split created, both left for a follow-up:

1. **`/faq/` meta description and lead now describe content that left.** The meta names cost, timing, ownership and unavailability; three of those four are on `/services/` now. The lead says "money, timing, ownership, and the risks" with the same problem. "How long it takes" is an empty group, so `/faq/` has no timing section at all.
2. **`/zero-to-one/` has a section headed "What is not in it." and now the question "What is not included in Zero to One?" below it.** Same content twice on one page.

Neither is a code issue and both need a copy decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
