### PR TITLE
Title case every page, dash the brand separator, and move Zero to One to two weeks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,8 @@
 - Write code document in ASD-STE100
 - Write page content and blog posts in a clear, humanized tone. No trace of AI tone.
 - Do not use "—" character mid sentence.
+- Do not use British English; use American English.
+- Always use `Chicago Manual of Style Title Case` for page titles.
 - When writing a blog post:
   - make sure the content is SEO optimized.
   - always end the post with a "Summary" section summarizing the entire post in clear language.

--- a/config.php
+++ b/config.php
@@ -19,7 +19,7 @@ $workIsPublic = true;
 $pricing = [
     'setup' => 1500,
     'monthly' => 50,
-    'turnaround' => '~1 week',
+    'turnaround' => '~2 weeks',
     'symbol' => '$',
     'currency' => 'USD',
 ];
@@ -316,10 +316,10 @@ return [
             ],
         ],
         [
-            'q' => 'Why is this about a week when other work takes months?',
+            'q' => 'Why is this about two weeks when other work takes months?',
             'page' => '/zero-to-one/',
             'a' => [
-                'Because it\'s the same defined list every time, with one round of changes: a website, the words, the domain and hosting, and your Google listing. The narrow scope is what makes a week possible. Nothing is being rushed to fit it.',
+                'Because it\'s the same defined list every time, with one round of changes: a website, the words, the domain and hosting, and your Google listing. The narrow scope is what makes two weeks possible. Nothing is being rushed to fit it.',
                 'The moment a business needs online ordering or a booking system, it\'s a different job with a different number. I won\'t squeeze it in.',
             ],
         ],

--- a/source/_caseStudies/broker-monitoring.md
+++ b/source/_caseStudies/broker-monitoring.md
@@ -1,7 +1,7 @@
 ---
 extends: _layouts.case-study
 section: content
-title: 'The metrics a broker could not buy'
+title: 'The Metrics a Broker Could Not Buy'
 description: 'A monitoring layer that let a brokerage watch its traders on its own measures rather than the ones its trading platform happened to report.'
 contactHeading: 'Got something like this?'
 contactIntro: "Describe it in a paragraph. You will get an honest answer about whether I am the right person for it, including the times when I am not."

--- a/source/_caseStudies/top-menu.md
+++ b/source/_caseStudies/top-menu.md
@@ -1,7 +1,7 @@
 ---
 extends: _layouts.case-study
 section: content
-title: 'A menu that changes without a print run'
+title: 'A Menu That Changes without a Print Run'
 description: 'Top Menu: a digital menu and ordering platform for cafés and restaurants, built and run over five years as lead engineer.'
 contactHeading: 'Got something like this?'
 contactIntro: "Describe it in a paragraph. You will get an honest answer about whether I am the right person for it, including the times when I am not."

--- a/source/_components/post-cta.blade.php
+++ b/source/_components/post-cta.blade.php
@@ -60,7 +60,7 @@
 
         @if ($ctaSecondary)
             <a class="btn btn--ghost" href="{{ $page->baseUrl }}/{{ ltrim($ctaSecondary, '/') }}">
-                <span>{{ $page->ctaSecondaryLabel ?: 'A website in about a week' }}</span>
+                <span>{{ $page->ctaSecondaryLabel ?: 'A website in about two weeks' }}</span>
             </a>
         @endif
     </div>

--- a/source/_includes/structured-data.blade.php
+++ b/source/_includes/structured-data.blade.php
@@ -166,7 +166,7 @@
                 // The last item takes the name of the page. An intermediate
                 // segment is a section, and a slug is not a readable name.
                 // Use $pageTitle, not $title. $title can contain the
-                // " · Hesam Rad" suffix, which puts the brand in the crumb.
+                // " - Hesam Rad" suffix, which puts the brand in the crumb.
                 'name' => $isLast
                     ? ($page->title ?: $pageTitle)
                     : ($sectionNames[$segment] ?? Str::title(str_replace('-', ' ', $segment))),

--- a/source/_layouts/main.blade.php
+++ b/source/_layouts/main.blade.php
@@ -19,7 +19,7 @@
      * - The full title becomes more than 60 characters.
      */
     $pageTitle = $yield('title');
-    $brandSuffix = ' · ' . $page->siteName;
+    $brandSuffix = ' - ' . $page->siteName;
     $titleLimit = 60;
     $needsBrand = ! $page->disableTitlePrefix
         && stripos($pageTitle, $page->siteName) === false

--- a/source/_posts/agency-or-one-independent-engineer.md
+++ b/source/_posts/agency-or-one-independent-engineer.md
@@ -1,7 +1,7 @@
 ---
 extends: _layouts.post
 section: content
-title: 'Agency or one independent engineer: the honest comparison'
+title: 'Agency or One Independent Engineer: The Honest Comparison'
 description: 'The comparison people make is cost. The one that decides the outcome is risk, and an agency''s risks are the opposite of an independent engineer''s.'
 tags:
 robots:

--- a/source/feed.blade.php
+++ b/source/feed.blade.php
@@ -18,7 +18,7 @@ permalink: /feed.xml
 @endphp
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
     <channel>
-        <title>{{ $page->siteName }} · Blog</title>
+        <title>{{ $page->siteName }} - Blog</title>
         <link>{{ $page->baseUrl }}/blog/</link>
         <description>{{ $page->siteTagline }}</description>
         <language>{{ $page->postLanguage }}</language>

--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -1,7 +1,7 @@
 @extends('_layouts.main')
 
 {{-- This title contains the site name, therefore the layout adds no suffix. --}}
-@section('title', 'Hesam Rad · Independent software engineer')
+@section('title', 'Hesam Rad - Independent Software Engineer')
 
 {{-- Keep this description below 120 characters. A phone cuts the search snippet
      at approximately that length. --}}

--- a/source/projects.blade.php
+++ b/source/projects.blade.php
@@ -1,11 +1,11 @@
 ---
-title: Open source
+title: Open Source
 disableContact: true
 ---
 
 @extends('_layouts.main')
 
-@section('title', 'Open source')
+@section('title', 'Open Source')
 
 @section('description', 'Small open-source tools I built for my own work and published for anyone to use, plus a free URL shortener run as a non-profit.')
 

--- a/source/thank-you.blade.php
+++ b/source/thank-you.blade.php
@@ -1,11 +1,11 @@
 ---
-title: Thank you
+title: Thank You
 robots: noindex,follow
 disableContact: true
 ---
 @extends('_layouts.main')
 
-@section('title', 'Thank you')
+@section('title', 'Thank You')
 
 @section('description', 'Your message is in. I read every one myself and reply within a day, usually sooner.')
 

--- a/source/zero-to-one.blade.php
+++ b/source/zero-to-one.blade.php
@@ -48,9 +48,12 @@ contactIntro: "A couple of sentences is plenty: what you do and roughly where. I
     $showTally = $launched->count() >= 3;
 @endphp
 
-@section('title', 'Zero to One: a website in about a week')
+@section('title', 'Zero to One: A Website in About Two Weeks')
 
-@section('description', 'Taking ' . $target . ' businesses from no website at all to one that works. A fixed price, about a week, and the whole thing handled for you.')
+{{-- Keep this close to the opening paragraph on the page. A description that
+     reads like a different page invites Google to write its own snippet out of
+     the body copy, which is what it did with the earlier wording. --}}
+@section('description', 'Zero to One gets ' . $target . ' businesses with no website online, properly. Yours is built around what you do, at a fixed price, in about two weeks.')
 
 @section('body')
     <div class="shell section page-head">
@@ -59,7 +62,7 @@ contactIntro: "A couple of sentences is plenty: what you do and roughly where. I
         <h1>Zero to One.</h1>
 
         <p class="lead prose">Zero to One is a campaign with one aim: get {{ $target }} businesses that have no website
-            online, properly. Yours is built around what you do, at a fixed price, in about a week. I handle every part
+            online, properly. Yours is built around what you do, at a fixed price, in about two weeks. I handle every part
             of it, including writing the words.</p>
 
         <p class="lead prose">Plenty of good businesses still don't have one. Usually it isn't that they decided
@@ -150,7 +153,7 @@ contactIntro: "A couple of sentences is plenty: what you do and roughly where. I
         <div class="shell">
             <div class="grid grid--halves">
                 <div class="section-head section-head--start">
-                    <h2>How the week goes.</h2>
+                    <h2>How the two weeks go.</h2>
                     <p class="dim">Four steps, and only the first one needs anything from you.</p>
                 </div>
 


### PR DESCRIPTION
Three SEO changes that all land on the same handful of title and metadata lines.

## The brand separator is a dash now

`·` became `-` everywhere a title is built: the homepage title, the ` - Hesam Rad` suffix the layout appends to every other page, the RSS channel title, and one comment that quoted the old string.

The dash is a character shorter than the dot, so no page crosses the 60 character limit at [main.blade.php:26](../blob/seo/titles-separator-and-two-week-turnaround/source/_layouts/main.blade.php#L26) that strips the brand off a long title. Verified against the built output.

## Zero to One says two weeks

The turnaround moved from about a week to about two weeks. Everywhere it is stated:

- head title and meta description
- the opening paragraph
- the steps heading, now "How the two weeks go."
- `turnaround` in `$pricing`, which feeds the price panel
- the FAQ entry that explains why the work is fast, question and answer. It renders on the page and in the FAQPage JSON-LD.
- the default label on the blog post call to action

Step two still says the draft lands "two or three days after the call". That is when you see something, not when it goes live, so it stays true.

## Zero to One has a description Google might actually use

Google was discarding the old meta description and writing its own snippet out of the page's opening paragraph, because the two said different things. The new description says what that paragraph says. That is the only reliable way to ask for it back, though Google rewrites snippets at will and this is a nudge rather than a guarantee.

## Every page title is Chicago title case

Per the new rule in `CLAUDE.md`.

| Was | Now |
|---|---|
| Open source | Open Source |
| Thank you | Thank You |
| Zero to One: a website in about two weeks | Zero to One: A Website in About Two Weeks |
| Agency or one independent engineer: the honest comparison | Agency or One Independent Engineer: The Honest Comparison |
| A menu that changes without a print run | A Menu That Changes without a Print Run |
| The metrics a broker could not buy | The Metrics a Broker Could Not Buy |

Already conforming: `Hesam Rad - Independent Software Engineer`, `About Hesam Rad`, `Blog`, `Work`, `Services`, `Questions`, `Not Found`.

Both the `@section('title', …)` and the front matter `title:` changed on each page, so the breadcrumbs and the JSON-LD agree with the tag.

Where Chicago keeps a word lowercase: `or` is a coordinating conjunction; `without` and the `to` in "Zero to One" are prepositions, lowercase at any length under 8.159; `a` is an article. `That`, `Not` and `About` stay capitalized as a subordinating conjunction and two adverbs. `About` there means approximately, modifying "two weeks". `The` and `A` are capitalized after a colon as the first word of a subtitle.

## For the reviewer

**The post and both case studies now show a Title Case `<h1>`.** Their front matter `title:` is both the tag and the visible headline ([post.blade.php:106](../blob/seo/titles-separator-and-two-week-turnaround/source/_layouts/post.blade.php#L106), [case-study.blade.php:45](../blob/seo/titles-separator-and-two-week-turnaround/source/_layouts/case-study.blade.php#L45)), so those three headlines are Title Case while every other heading on the site stays sentence case. If that reads wrong, the fix is a separate `seoTitle` for the tag and a sentence case `title` for the headline. Say so and I will split them.

`CLAUDE.md` also gained an American English rule in this commit. Nothing here was rewritten for it, and the existing copy has not been checked against it.

Verified with `jigsaw build` and a read of the built titles and descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)