### PR TITLE
Put the Zero to One campaign behind a switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,27 @@ Two fields control whether the case study appears:
 
 Name a client only when you have permission.
 
+## The campaign switch
+
+`campaignIsLive` in `config.php` controls the Zero to One campaign.
+
+Set the value to `false` to remove the campaign from the site. The site then:
+
+- shows a short holding page at `/zero-to-one/`, with `noindex`
+- keeps the URL at 200, because the address is indexed and links point to it
+- removes the campaign link from the navigation and the footer
+- removes the six campaign questions
+- shows one button in the home page hero
+- removes the second button at the end of a post
+
+Set the value to `true` to put the campaign back.
+
+The prices in `pricing` stay in `config.php` when the switch is `false`. No
+template reads them then. They are what the campaign starts again from.
+
+The `noindex` also keeps the URL out of `sitemap.xml`. The sitemap listener
+reads the value of the page and removes the page for itself.
+
 ## Themes
 
 The site has a light theme and a dark theme.

--- a/config.php
+++ b/config.php
@@ -1,11 +1,27 @@
 <?php
 
 /*
- * A PHP array literal cannot reference its own keys. These two values are
+ * A PHP array literal cannot reference its own keys. These three values are
  * therefore outside the array below. The case-studies collection filter closes
- * over $workIsPublic, and the FAQ answers read $pricing.
+ * over $workIsPublic, the campaign questions close over $campaignIsLive, and
+ * the FAQ answers read $pricing.
  */
 $workIsPublic = true;
+
+/*
+ * The Zero to One campaign.
+ *
+ * Set this to false to remove the campaign from the site. The page at
+ * /zero-to-one/ then shows a short holding page with noindex, the link leaves
+ * the navigation and the footer, the campaign questions stop, the home page
+ * hero shows one button, and a post gets no second button.
+ *
+ * Set this to true to put the campaign back.
+ *
+ * The prices below stay when this is false. No template reads them then, and
+ * they are what the campaign starts again from.
+ */
+$campaignIsLive = false;
 
 /*
  * The Zero to One prices.
@@ -58,6 +74,11 @@ return [
     // page, and the generation of sample case studies. Set it at the top of
     // this file.
     'workIsPublic' => $workIsPublic,
+
+    // This value controls the campaign page, the nav entry, the footer entry,
+    // the campaign questions, the home page hero and the button at the end of
+    // a post. Set it at the top of this file.
+    'campaignIsLive' => $campaignIsLive,
 
     // The site is static and has no server. The contact form therefore posts to
     // a Cloudflare Worker (refer to worker/). These two values are public. The
@@ -283,54 +304,60 @@ return [
         // ── On /zero-to-one/ only ────────────────────────────────────────
         // The campaign, and the only place on the site that states a price.
         // Keep it that way: an answer here can name a figure, and an answer
-        // anywhere else cannot. When the campaign ends, this block and the
-        // page go together and no answer elsewhere needs a rewrite.
-        [
-            'q' => 'What does it cost?',
-            'page' => '/zero-to-one/',
-            'open' => true,
-            'a' => [
-                $money($pricing['setup']) . ' once to build it and put it live, then ' . $money($pricing['monthly']) . ' a month to keep it running. That is the whole of it, and it does not move once we have agreed the work.',
-                'Anything outside the list on this page is a different job with its own fixed price, and that number comes once the plan is written.',
+        // anywhere else cannot. $campaignIsLive removes this block with the
+        // page, therefore no answer elsewhere needs a rewrite.
+        //
+        // The spread is what makes the switch possible. A `page` key alone
+        // puts a question on the page, and faq-section.blade.php would show
+        // these six on the holding page, prices and all.
+        ...($campaignIsLive ? [
+            [
+                'q' => 'What does it cost?',
+                'page' => '/zero-to-one/',
+                'open' => true,
+                'a' => [
+                    $money($pricing['setup']) . ' once to build it and put it live, then ' . $money($pricing['monthly']) . ' a month to keep it running. That is the whole of it, and it does not move once we have agreed the work.',
+                    'Anything outside the list on this page is a different job with its own fixed price, and that number comes once the plan is written.',
+                ],
             ],
-        ],
-        [
-            'q' => 'What does the monthly fee cover?',
-            'page' => '/zero-to-one/',
-            'a' => [
-                $money($pricing['monthly']) . ' a month covers hosting, the domain renewal, security updates, backups, and small changes when you need them: new opening hours, a price change, a few new photos. Email me and it gets done.',
+            [
+                'q' => 'What does the monthly fee cover?',
+                'page' => '/zero-to-one/',
+                'a' => [
+                    $money($pricing['monthly']) . ' a month covers hosting, the domain renewal, security updates, backups, and small changes when you need them: new opening hours, a price change, a few new photos. Email me and it gets done.',
+                ],
             ],
-        ],
-        [
-            'q' => 'Can I stop paying the monthly fee?',
-            'page' => '/zero-to-one/',
-            'a' => [
-                'Then stop. There\'s no minimum term. The domain is registered to you, and I\'ll hand over everything so you or anyone else can pick it up. Nothing in the paperwork keeps you here.',
+            [
+                'q' => 'Can I stop paying the monthly fee?',
+                'page' => '/zero-to-one/',
+                'a' => [
+                    'Then stop. There\'s no minimum term. The domain is registered to you, and I\'ll hand over everything so you or anyone else can pick it up. Nothing in the paperwork keeps you here.',
+                ],
             ],
-        ],
-        [
-            'q' => 'How much work is this for me?',
-            'page' => '/zero-to-one/',
-            'a' => [
-                'Half an hour on a call, and that\'s the whole of your homework. I write the words from what you tell me, because sitting down to write a page about your own business is the step that stalls most websites for months.',
+            [
+                'q' => 'How much work is this for me?',
+                'page' => '/zero-to-one/',
+                'a' => [
+                    'Half an hour on a call, and that\'s the whole of your homework. I write the words from what you tell me, because sitting down to write a page about your own business is the step that stalls most websites for months.',
+                ],
             ],
-        ],
-        [
-            'q' => 'Why is this about two weeks when other work takes months?',
-            'page' => '/zero-to-one/',
-            'a' => [
-                'Because it\'s the same defined list every time, with one round of changes: a website, the words, the domain and hosting, and your Google listing. The narrow scope is what makes two weeks possible. Nothing is being rushed to fit it.',
-                'The moment a business needs online ordering or a booking system, it\'s a different job with a different number. I won\'t squeeze it in.',
+            [
+                'q' => 'Why is this about two weeks when other work takes months?',
+                'page' => '/zero-to-one/',
+                'a' => [
+                    'Because it\'s the same defined list every time, with one round of changes: a website, the words, the domain and hosting, and your Google listing. The narrow scope is what makes two weeks possible. Nothing is being rushed to fit it.',
+                    'The moment a business needs online ordering or a booking system, it\'s a different job with a different number. I won\'t squeeze it in.',
+                ],
             ],
-        ],
-        [
-            'q' => 'What is not included?',
-            'page' => '/zero-to-one/',
-            'a' => [
-                'A visual identity invented from scratch. The site is built for your business, but the look isn\'t designed from nothing. That\'s a separate job at a separate price. Logos, branding and photography aren\'t part of it either.',
-                'Payments, online ordering, booking systems and customer logins are all real work, so they\'re quoted separately.',
+            [
+                'q' => 'What is not included?',
+                'page' => '/zero-to-one/',
+                'a' => [
+                    'A visual identity invented from scratch. The site is built for your business, but the look isn\'t designed from nothing. That\'s a separate job at a separate price. Logos, branding and photography aren\'t part of it either.',
+                    'Payments, online ordering, booking systems and customer logins are all real work, so they\'re quoted separately.',
+                ],
             ],
-        ],
+        ] : []),
     ],
 
     // The link to the full set of recommendations. Set it to null to remove the

--- a/source/_components/post-cta.blade.php
+++ b/source/_components/post-cta.blade.php
@@ -20,14 +20,19 @@
     /*
      * `ctaSecondary: false` removes the second button.
      *
-     * Compare `ctaSecondary` against null. Do not write `?: '/zero-to-one/'`. A
-     * fallback that is not empty makes the guard below always true, and the
+     * The default target is the campaign, therefore it leaves with the
+     * campaign. `$campaignIsLive` false gives false here, and a post that sets
+     * no `ctaSecondary` of its own then shows one button.
+     *
+     * Compare `ctaSecondary` against null. Do not write `?: $campaignDefault`.
+     * A fallback that is not empty makes the guard below always true, and the
      * second button then shows on each post.
      *
      * Keep the ltrim below. A value without a leading slash joins directly to
      * the host, for example `hesamrad.comprojects/`.
      */
-    $ctaSecondary = $page->ctaSecondary === null ? '/zero-to-one/' : $page->ctaSecondary;
+    $campaignDefault = $page->campaignIsLive ? '/zero-to-one/' : false;
+    $ctaSecondary = $page->ctaSecondary === null ? $campaignDefault : $page->ctaSecondary;
 
     /*
      * The first button is the booking button on each post. A post sets

--- a/source/_includes/footer.blade.php
+++ b/source/_includes/footer.blade.php
@@ -20,7 +20,7 @@
             'title' => 'Work with me',
             'links' => [
                 ['label' => 'Services', 'href' => $page->baseUrl . '/services/'],
-                ['label' => 'Zero to One', 'href' => $page->baseUrl . '/zero-to-one/'],
+                ['label' => 'Zero to One', 'href' => $page->baseUrl . '/zero-to-one/', 'when' => $page->campaignIsLive],
                 ['label' => 'Case studies', 'href' => $page->baseUrl . '/work/', 'when' => $page->workIsPublic],
                 ['label' => 'Questions', 'href' => $page->baseUrl . '/faq/'],
                 ['label' => 'Start a conversation', 'href' => $page->baseUrl . '/#contact'],

--- a/source/_includes/header.blade.php
+++ b/source/_includes/header.blade.php
@@ -16,7 +16,12 @@
         $links[] = ['label' => 'Work', 'path' => 'work', 'href' => $page->baseUrl . '/work/'];
     }
 
-    $links[] = ['label' => 'Zero to One', 'path' => 'zero-to-one', 'href' => $page->baseUrl . '/zero-to-one/'];
+    // The campaign switch, for the same reason as the flag above: the holding
+    // page carries noindex, therefore the nav must not point at it.
+    if ($page->campaignIsLive) {
+        $links[] = ['label' => 'Zero to One', 'path' => 'zero-to-one', 'href' => $page->baseUrl . '/zero-to-one/'];
+    }
+
     $links[] = ['label' => 'Services', 'path' => 'services', 'href' => $page->baseUrl . '/services/'];
     $links[] = ['label' => 'Blog', 'path' => 'blog', 'href' => $page->baseUrl . '/blog/'];
 @endphp

--- a/source/_posts/agency-or-one-independent-engineer.md
+++ b/source/_posts/agency-or-one-independent-engineer.md
@@ -235,7 +235,8 @@ for both:
 4. **What does the first deliverable look like, and when?** If nothing is
    visible for two months, that's a warning regardless of who you hired.
 5. **What is explicitly not included?** A fixed price only stays fixed if both
-   sides can see the edges. [Zero to One states its exclusions on the page](/zero-to-one/) for exactly that reason.
+   sides can see the edges. Any fixed price I quote comes with its exclusions
+   written down for exactly that reason.
 
 It would be a poor article that asked you to interrogate everyone but me. My
 answers to all five are [on the questions page](/faq/): ownership, what happens

--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -40,17 +40,29 @@
                 There's no agency here and no template. One engineer who builds the thing, and who's still around when it needs changing.
             </p>
 
+            {{-- The two buttons are a fork, and the fork needs the campaign.
+                 "Specific" earns its place against "I just need a website"
+                 beside it, and the line below asks which of the two. With the
+                 campaign off, one button and a label that stands alone. --}}
             <div class="btn-row">
-                <a class="btn btn--primary" href="{{ $page->baseUrl }}/services/">
-                    <span>I need something built</span>
-                    @include('_components.icon', ['name' => 'arrow-right', 'class' => 'btn__icon'])
-                </a>
-                <a class="btn btn--ghost" href="{{ $page->baseUrl }}/zero-to-one/">
-                    <span>I just need a website</span>
-                </a>
+                @if ($page->campaignIsLive)
+                    <a class="btn btn--primary" href="{{ $page->baseUrl }}/services/">
+                        <span>I need something specific</span>
+                        @include('_components.icon', ['name' => 'arrow-right', 'class' => 'btn__icon'])
+                    </a>
+                    <a class="btn btn--ghost" href="{{ $page->baseUrl }}/zero-to-one/">
+                        <span>I just need a website</span>
+                    </a>
+                @else
+                    <a class="btn btn--primary" href="{{ $page->baseUrl }}/services/">
+                        <span>I need something built</span>
+                        @include('_components.icon', ['name' => 'arrow-right', 'class' => 'btn__icon'])
+                    </a>
+                @endif
             </div>
 
-            <p class="hero__route">Not sure which? <a href="#contact">Describe it in a paragraph</a> and I'll tell you.</p>
+            <p class="hero__route">{{ $page->campaignIsLive ? 'Not sure which?' : 'Not sure where to start?' }}
+                <a href="#contact">Describe it in a paragraph</a> and I'll tell you.</p>
         </div>
     </section>
 

--- a/source/zero-to-one.blade.php
+++ b/source/zero-to-one.blade.php
@@ -7,6 +7,29 @@ contactIntro: "A couple of sentences is plenty: what you do and roughly where. I
 @extends('_layouts.main')
 
 @php
+    /*
+     * The campaign switch.
+     *
+     * `false` keeps this URL at 200 and puts a short holding page here: no
+     * price, no turnaround, no campaign name, and noindex. The URL stays alive
+     * on purpose. It is indexed, links point at it, and the campaign comes
+     * back to this same address.
+     *
+     * Front matter cannot read the switch. The values that name the campaign
+     * are therefore reassigned below. case-study.blade.php assigns `robots` in
+     * the same way.
+     *
+     * The noindex is also what keeps the URL out of the sitemap.
+     * GenerateSitemap.php reads this value and drops the page for itself.
+     */
+    $campaignIsLive = $page->campaignIsLive;
+
+    if (! $campaignIsLive) {
+        $page->robots = 'noindex,nofollow';
+        $page->title = 'A Website for Your Business';
+        $page->contactIntro = 'A couple of sentences is plenty: what you do and roughly where. I\'ll tell you what it would take, and what it would cost.';
+    }
+
     $target = 25;
 
     // Add a business here only after its website is live.
@@ -48,14 +71,21 @@ contactIntro: "A couple of sentences is plenty: what you do and roughly where. I
     $showTally = $launched->count() >= 3;
 @endphp
 
-@section('title', 'Zero to One: A Website in About Two Weeks')
+@section('title', $campaignIsLive ? 'Zero to One: A Website in About Two Weeks' : 'A Website for Your Business')
 
 {{-- Keep this close to the opening paragraph on the page. A description that
      reads like a different page invites Google to write its own snippet out of
-     the body copy, which is what it did with the earlier wording. --}}
-@section('description', 'Zero to One gets ' . $target . ' businesses with no website online, properly. Yours is built around what you do, at a fixed price, in about two weeks.')
+     the body copy, which is what it did with the earlier wording.
+
+     The holding page carries its own description. The page is noindex, so no
+     search result uses it, but an empty section makes the layout fall back to
+     the body text and a link preview then quotes the holding note. --}}
+@section('description', $campaignIsLive
+    ? 'Zero to One gets ' . $target . ' businesses with no website online, properly. Yours is built around what you do, at a fixed price, in about two weeks.'
+    : 'A website for a business that has none: built, launched and looked after. Tell me about the business and I will give you a price and a date.')
 
 @section('body')
+    @if ($campaignIsLive)
     <div class="shell section page-head">
         @include('_components.breadcrumbs')
 
@@ -313,4 +343,26 @@ contactIntro: "A couple of sentences is plenty: what you do and roughly where. I
             ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT) !!}
         </script>
     @endpush
+    @else
+        {{-- The holding page. It states no price and no turnaround, because
+             those are the terms under revision, and it names no campaign.
+
+             The Offer above sits inside the branch that is now closed, so the
+             page publishes no structured price either.
+
+             main.blade.php adds the contact block after this, therefore the
+             page still has a way to reach me. --}}
+        <div class="shell section page-head">
+            @include('_components.breadcrumbs')
+
+            <h1>A Website for Your Business.</h1>
+
+            <p class="lead prose">I'm rebuilding how this offer works, so it's off the page for now.</p>
+
+            <p class="lead prose">If your business doesn't have a website yet, tell me about it below and I'll give
+                you a price and a date.</p>
+
+            <p class="mt-md"><a href="{{ $page->baseUrl }}/services/">What I take on</a></p>
+        </div>
+    @endif
 @endsection


### PR DESCRIPTION
Temporarily takes the Zero to One campaign off the site while its terms are reworked, without giving up the URL.

## Why not a redirect

The apex is served straight off GitHub Pages (`server: GitHub.com`, no `cf-ray`). Cloudflare only fronts `hello.hesamrad.com` for the contact form. Static hosting means no 301, no 302, no 503, and the only redirect available is a meta refresh, which Google reads as permanent.

A 301 would be wrong regardless. It tells Google the page is permanently gone and folds its signals into the target, on a URL we plan to reuse in a few weeks. A temporary removal is already filed in Search Console, which hides the URL from results while leaving it indexed.

So `/zero-to-one/` stays at 200 and serves a holding page.

## What the switch does

`$campaignIsLive` at the top of `config.php`, beside the existing `$workIsPublic`. Set to `false`:

- `/zero-to-one/` returns 200 with a short holding page, `noindex,nofollow`. No price, no turnaround, no campaign name.
- Nav and footer links drop out.
- The six campaign questions stop rendering. They would otherwise attach to the holding page by path and print the prices.
- Home hero collapses to one button. The "I need something specific" label only earns its keep against the campaign button beside it, so it reverts to "I need something built", and "Not sure which?" becomes "Not sure where to start?"
- Post CTA default becomes `false`, so the second button disappears. No live post uses the default today, but `template.md` sets no `ctaSecondary`, so the next post would have picked up the campaign link.
- The Offer JSON-LD needs no separate gate. It is a `@push` inside the page body, so it goes with the body.
- The `noindex` keeps the URL out of `sitemap.xml` on its own, via the existing `isNoIndex` check in `GenerateSitemap.php`.

Set to `true` and all of it returns.

## Unchanged on purpose

`$pricing` and `$money` stay in `config.php`. Nothing reads them while the switch is off, and they are the values being reworked. Deleting them would mean retyping them to relaunch. `priceRange => '$$'` on the business node stays too; it is a site-wide band, not a campaign claim.

## Content change

One link in the body of the agency post pointed at the campaign. Reworded to keep the argument without the link:

> A fixed price only stays fixed if both sides can see the edges. Any fixed price I quote comes with its exclusions written down for exactly that reason.

`updated_at` deliberately not bumped. The edit removes a link and gives a reader nothing new, and bumping `lastmod` for cosmetic housekeeping is the habit `GenerateSitemap.php` already argues against.

## For the reviewer

Both states were built and checked.

Off: holding page renders with the right title, robots and breadcrumb; no Offer, no questions, no price string; contact block still present with a rewritten intro; nav and hero correct; `sitemap.xml` has 0 occurrences; no `zero-to-one` reference in any HTML outside the stub's own directory.

On: nav link, hero fork, title, `index,follow`, Offer, six questions, `$1,500` and the sitemap entry all return.

One known gap: `$target`, `$businesses` and `$placeholders` still compute when the switch is off. They are inert (empty literal, fully commented out, both booleans false) and reach no output. Left alone so the diff does not turn into a 40-line reindent on a change that gets reverted at relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)