### PR TITLE
Open external links in blog posts in a new tab

### DIFF
--- a/config.php
+++ b/config.php
@@ -608,6 +608,41 @@ return [
     },
 
     /**
+     * Returns $html with every off-site link set to open in a new tab.
+     *
+     * The markdown parser writes a plain <a>, therefore the attributes go on
+     * here. `rel` keeps the new page away from this one.
+     *
+     * A link to the site itself stays in the same tab. The host of `baseUrl`
+     * is localhost during a local build, therefore the production host counts
+     * as the same site too.
+     */
+    'withExternalLinksInNewTab' => function ($page, $html) {
+        $siteHosts = collect([parse_url($page->baseUrl, PHP_URL_HOST), 'hesamrad.com'])
+            ->map(fn ($host) => preg_replace('/^www\./', '', (string) $host))
+            ->filter()
+            ->all();
+
+        return preg_replace_callback('/<a\b([^>]*?)href="(https?:\/\/[^"]+)"([^>]*)>/i', function ($match) use ($siteHosts) {
+            $host = preg_replace('/^www\./', '', (string) parse_url($match[2], PHP_URL_HOST));
+            $attributes = $match[1] . $match[3];
+
+            // The author can write the attributes in the markdown itself.
+            if (in_array($host, $siteHosts, true) || stripos($attributes, 'target=') !== false) {
+                return $match[0];
+            }
+
+            $added = ' target="_blank"';
+
+            if (stripos($attributes, 'rel=') === false) {
+                $added .= ' rel="noopener noreferrer"';
+            }
+
+            return '<a' . $match[1] . 'href="' . $match[2] . '"' . $match[3] . $added . '>';
+        }, $html);
+    },
+
+    /**
      * Returns the FAQPage node of the current page as encoded JSON, or ''.
      *
      * The node is built here and not in a template. Blade compiles the word

--- a/source/_layouts/post.blade.php
+++ b/source/_layouts/post.blade.php
@@ -55,7 +55,7 @@
              * This code adds the ids and collects the headings in one pass.
              * The contents list and the anchors thus always agree.
              */
-            $body = $__env->yieldContent('content');
+            $body = $page->withExternalLinksInNewTab($__env->yieldContent('content'));
             $flat = [];
 
             // This callback finds h2 and h3 in document order. The nesting


### PR DESCRIPTION
## What changed

- New page helper `withExternalLinksInNewTab` in `config.php`. It rewrites body anchors that point off the site, adding `target="_blank"` and `rel="noopener noreferrer"`.
- `source/_layouts/post.blade.php` runs the rendered markdown body through the helper before the heading/anchor pass.

## Why

Markdown writes a plain `<a>`, so every citation in a post pulled the reader off the page. Posts here carry a lot of source links, and losing the post to a back button hurts the read. The CSS already styled `.rich-text a[target='_blank']` with the `↗` marker, so the style side expected this.

## Notes for a reviewer

- Same-site links stay in the same tab. The check covers the `baseUrl` host and `hesamrad.com`, because `baseUrl` is localhost during a local build.
- Relative links (`/work/`, `/faq/#…`) are untouched: the pattern matches absolute `http(s)` hrefs only.
- A link that already has `target=` keeps it, and `rel` is only added when absent, so an author can override in the markdown.
- The helper is page-scoped, so `case-study.blade.php` can call it later if wanted. This PR does not change case studies.
- Verified with a local `jigsaw build`: both posts convert their off-site links, internal links unchanged.