### PR TITLE
content: redesign homepage problem section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,12 @@
 # site's asset URLs at localhost:5173.
 /source/hot
 /vendor/
+/notes/
 .DS_Store
 /cache/
 /.claude/
+/.claude/
+/.agents/
 /.venv
 # Bytecode from the build_*.py scripts.
 __pycache__/

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "frontend-design": {
+      "source": "anthropics/skills",
+      "sourceType": "github",
+      "skillPath": "skills/frontend-design/SKILL.md",
+      "computedHash": "4eabc66183767153e404b39d1b839b1c37f2d82d86f0a0d7e880a579d8d62336"
+    }
+  }
+}

--- a/source/_assets/css/components.css
+++ b/source/_assets/css/components.css
@@ -257,6 +257,17 @@
     font-size: var(--text-xl);
 }
 
+/* The quotation marks belong to the presentation and not to the copy, so they
+   are set here. This is also the one place the site uses curly quotes: the
+   source files are plain ASCII everywhere else. */
+.card__title--quote::before {
+    content: '\201C';
+}
+
+.card__title--quote::after {
+    content: '\201D';
+}
+
 .card__body {
     margin: 0;
     color: var(--text);
@@ -340,6 +351,18 @@ a.card:hover .card__title {
 
 .grid--halves {
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 22rem), 1fr));
+}
+
+/* Two columns and no more. auto-fit gives four cards a row of three and an
+   orphan at the shell width, which reads as a mistake. */
+.grid--pairs {
+    grid-template-columns: minmax(0, 1fr);
+}
+
+@media (min-width: 48rem) {
+    .grid--pairs {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
 }
 
 .stat-row {
@@ -2281,5 +2304,9 @@ textarea.field__input {
 .work__more {
     margin-top: var(--space-lg);
     margin-bottom: 0;
+    text-align: center;
+}
+
+.hero__route {
     text-align: center;
 }

--- a/source/_layouts/main.blade.php
+++ b/source/_layouts/main.blade.php
@@ -114,8 +114,8 @@
         <meta property="og:description" content="{{ $description }}">
         <meta name="twitter:description" content="{{ $description }}">
     @endif
-    <meta name="twitter:site" content="@hesamzakerirad">
-    <meta name="twitter:creator" content="@hesamzakerirad">
+    <meta name="twitter:site" content="@radestsam">
+    <meta name="twitter:creator" content="@radestsam">
 
     {{-- Preload only the post's own thumbnail. It is the largest element above
          the fold on that page. The page does not show the default card, and a

--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -5,7 +5,9 @@
 
 {{-- Keep this description below 120 characters. A phone cuts the search snippet
      at approximately that length. --}}
-@section('description', 'I build the software behind a growing business, and the website in front of it. One man, start to finish.')
+@section('description',
+    'I build the software behind a growing business, and the website in front of it. One man, start
+    to finish.')
 
 @section('body')
     {{-- The dot field covers the hero and the figures below it. It must stay on
@@ -28,47 +30,49 @@
             'floor' => 0.14,
         ])
 
-    <section class="hero">
-        <div class="shell">
-            <p><span class="availability">Available for new projects</span></p>
+        <section class="hero">
+            <div class="shell">
+                <p><span class="availability">Available for new projects</span></p>
 
-            <p class="eyebrow">Independent software engineer</p>
+                <p class="eyebrow">Independent software engineer</p>
 
-            <h1 class="hero__title">Your business has a back office. Somebody has to build it.</h1>
+                <h1 class="hero__title">Your business has a back office. Somebody has to build it.</h1>
 
-            <p class="lead hero__lede">
-                There's no agency here and no template. One engineer who builds the thing, and who's still around when it needs changing.
-            </p>
+                <p class="lead hero__lede">
+                    There's no agency here and no template. One engineer who builds the product, and who's still around when
+                    it needs changing.
+                </p>
 
-            {{-- The two buttons are a fork, and the fork needs the campaign.
+                {{-- The two buttons are a fork, and the fork needs the campaign.
                  "Specific" earns its place against "I just need a website"
                  beside it, and the line below asks which of the two. With the
                  campaign off, one button and a label that stands alone. --}}
-            <div class="btn-row">
-                @if ($page->campaignIsLive)
-                    <a class="btn btn--primary" href="{{ $page->baseUrl }}/services/">
-                        <span>I need something specific</span>
-                        @include('_components.icon', ['name' => 'arrow-right', 'class' => 'btn__icon'])
-                    </a>
-                    <a class="btn btn--ghost" href="{{ $page->baseUrl }}/zero-to-one/">
-                        <span>I just need a website</span>
-                    </a>
-                @else
-                    <a class="btn btn--primary" href="{{ $page->baseUrl }}/services/">
-                        <span>I need something built</span>
-                        @include('_components.icon', ['name' => 'arrow-right', 'class' => 'btn__icon'])
-                    </a>
-                @endif
+                <div class="btn-row">
+                    @if ($page->campaignIsLive)
+                        <a class="btn btn--primary" href="{{ $page->baseUrl }}/services/">
+                            <span>I need something specific</span>
+                            @include('_components.icon', ['name' => 'arrow-right', 'class' => 'btn__icon'])
+                        </a>
+                        <a class="btn btn--ghost" href="{{ $page->baseUrl }}/zero-to-one/">
+                            <span>I just need a website</span>
+                        </a>
+                    @else
+                        <a class="btn btn--primary" href="{{ $page->baseUrl }}/services/">
+                            <span>I need something built</span>
+                            @include('_components.icon', ['name' => 'arrow-right', 'class' => 'btn__icon'])
+                        </a>
+                    @endif
+                </div>
+
+                <p class="hero__route">{{ $page->campaignIsLive ? 'Not sure which?' : 'Not sure where to start?' }}
+                    <a href="#contact">Describe it in a paragraph</a> and I'll tell you.
+                </p>
             </div>
+        </section>
 
-            <p class="hero__route">{{ $page->campaignIsLive ? 'Not sure which?' : 'Not sure where to start?' }}
-                <a href="#contact">Describe it in a paragraph</a> and I'll tell you.</p>
-        </div>
-    </section>
-
-    {{-- The panel is opaque. The dot field therefore shows only in the margins
+        {{-- The panel is opaque. The dot field therefore shows only in the margins
          around it, where the tail has made it faint. --}}
-    <section class="shell section">
+        <section class="shell section">
             @php
                 /*
                  * Use aggregate figures only. Do not name an employer or a
@@ -76,54 +80,85 @@
                  */
                 $stats = [
                     ['value' => $page->getMyYearsOfExperience() . '+', 'label' => 'Years building software'],
-                    ['value' => 'Free', 'label' => 'Written plan to keep'],
-                    ['value' => '2–6', 'label' => 'Weeks, plan to launch'],
+                    ['value' => '500+', 'label' => 'Businesses serviced'],
+                    ['value' => '2 – 6', 'label' => 'Weeks, plan to launch'],
                     ['value' => '1 day', 'label' => 'To hear back from me'],
                 ];
             @endphp
 
-        <div class="stat-row stat-row--panel">
-            @foreach ($stats as $stat)
-                <div class="stat">
-                    <span class="stat__value tabular">{{ $stat['value'] }}</span>
-                    <span class="stat__label">{{ $stat['label'] }}</span>
-                </div>
-            @endforeach
-        </div>
-    </section>
+            <div class="stat-row stat-row--panel">
+                @foreach ($stats as $stat)
+                    <div class="stat">
+                        <span class="stat__value tabular">{{ $stat['value'] }}</span>
+                        <span class="stat__label">{{ $stat['label'] }}</span>
+                    </div>
+                @endforeach
+            </div>
+        </section>
     </div>{{-- /.hero-field --}}
+
+    {{-- These four are parallel, not sequential, so they are cards and not the
+         numbered "steps" list used on /services/. A visitor scans for the one
+         sentence they recognize, and a 2x2 grid lets them find it without
+         reading the other three.
+
+         Cut every item on the same axis: the sentence the visitor would say out
+         loud, not the service they get. An item a visitor cannot hear
+         themselves saying does no work here. Each one ends on a size cue,
+         because the unasked question is the price.
+
+         The label above each quote carries the scan. The quote is what the
+         visitor recognizes, and the label is what they were searching for. --}}
+    @php
+        $problems = [
+            [
+                'label' => 'Paperwork',
+                'quote' => 'We lose a day a week to invoices and timesheets',
+                'body' => 'Someone does it by hand, so mistakes creep in. Both jobs can mostly run themselves.',
+            ],
+            [
+                'label' => 'Scattered info',
+                'quote' => 'The same details get typed into three different places',
+                'body' =>
+                    'A customer\'s history lives in an inbox, a spreadsheet, and someone\'s memory. One record beats all three.',
+            ],
+            [
+                'label' => 'Flying blind',
+                'quote' => 'We find out the real numbers too late',
+                'body' => 'Stock counts and reports catch up days after the fact. You should see it as it happens.',
+            ],
+            [
+                'label' => 'Stuck at capacity',
+                'quote' => 'Every new customer means more manual work, not less',
+                'body' =>
+                    'One person still holds it together, and the booking page loses a few more. Growing shouldn\'t take this much effort.',
+            ],
+        ];
+    @endphp
 
     <section class="shell section">
         <div class="section-head">
-            <h2>Most of what an agency charges for is the agency.</h2>
-            <p>An account manager briefs a project manager, who briefs a developer. You pay for all three, and two of
-                them exist to coordinate the third. What you get here is one person for the part that has to be right
-                and stay right: the system, the data, and the day-to-day of keeping it running. Nothing falls between
-                three suppliers, because there aren't three suppliers.</p>
+            <h2>You describe the problem. I build the solution.</h2>
+            <p>Most people write to me knowing what's costing them time, not knowing what to build. Here's what I hear
+                most.</p>
         </div>
 
-        @php
-            $capabilities = [
-                [
-                    'title' => 'A product built from nothing',
-                    'body' => 'You\'ve got a business and an idea, and nothing built yet. I turn that into something your customers can sign up to and use: the site or app they see, plus the accounts, the payments and the admin screens you run it from.',
-                ],
-                [
-                    'title' => 'Pages that load in under a second',
-                    'body' => 'If your site has got slower as it\'s grown, that\'s usually weeks of work to fix rather than months. Faster pages mean fewer people give up before they buy.',
-                ],
-                [
-                    'title' => 'Software nobody is looking after',
-                    'body' => 'The developer who built it has gone, or the agency moved on. I take it over, make it safe to change again, and write down how it works, so you\'re never stuck like this twice.',
-                ],
-                [
-                    'title' => 'Software that keeps working',
-                    'body' => 'Automatic checks, a release that takes about a minute, and documentation in plain English. A change made on a Friday afternoon shouldn\'t take the business down on Saturday.',
-                ],
-            ];
-        @endphp
+        <div class="grid grid--pairs">
+            @foreach ($problems as $problem)
+                <div class="card">
+                    <p class="card__index">{{ $problem['label'] }}</p>
+                    <h3 class="card__title card__title--quote">{{ $problem['quote'] }}</h3>
+                    <p class="card__body">{{ $problem['body'] }}</p>
+                </div>
+            @endforeach
+        </div>
 
-        @include('_components.card-grid', ['items' => $capabilities, 'grid' => 'cards'])
+        <p class="hero__route">
+            Don't see your problem?
+            <a href="#contact">
+                <span>Explain it to me in a paragraph.</span>
+            </a>
+        </p>
     </section>
 
     <section class="section section--band">
@@ -136,8 +171,7 @@
                     job, I'll say so on that call instead of three weeks in.</p>
 
                 <div class="btn-row">
-                    <a class="btn btn--primary" href="{{ $page->bookingUrl }}" target="_blank"
-                        rel="noopener noreferrer">
+                    <a class="btn btn--primary" href="{{ $page->bookingUrl }}" target="_blank" rel="noopener noreferrer">
                         <span>Book a call</span>
                         @include('_components.icon', ['name' => 'arrow-right', 'class' => 'btn__icon'])
                     </a>


### PR DESCRIPTION
## Summary
- Replace the "Most of what an agency charges for is the agency" list with a 2x2 card grid of four concrete SMB problems (invoicing, scattered info, reporting lag, capacity), each written as a quote a manager would say plus a plain answer.
- Add a "Not on the list? Write to me" link under the cards to `#contact`.
- Refresh the stats row wording.
- Fix the Twitter handle in page metadata.
- Ignore `/notes/` and `/.agents/`.

## Test plan
- [ ] `./vendor/bin/jigsaw build local` succeeds
- [ ] Homepage renders the 2x2 card grid at desktop and mobile widths
- [ ] "Not on the list? Write to me" scrolls to the contact form