### PR TITLE
Fix the Search Console issues: dead URLs, a stale noindex, and one thin-linked post

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,50 @@ Two fields control whether the case study appears:
 
 Name a client only when you have permission.
 
+## Redirect an old URL
+
+GitHub Pages sends static files. It cannot send a 301. To move a URL, make a
+stub page that redirects.
+
+**Step 1.** Make a new file in `source/_redirects/`. Give the file any name.
+
+**Step 2.** Write this front matter:
+
+```yaml
+---
+extends: _layouts.redirect
+redirectFrom: blog/the-old-address
+redirectTo: /the-new-address/
+---
+```
+
+`redirectFrom` is the old path. Write it without a slash at the start and
+without a slash at the end. This field controls the output path, and the file
+name does not. A nested address is therefore correct in this flat directory.
+
+`redirectTo` is the new address. Write it with a slash at the start and a slash
+at the end.
+
+The stub sends the reader with a meta refresh. It also gives a canonical link
+to the new address. Search engines obey both. The stub stays out of the
+sitemap, out of the blog list, and out of the feed.
+
+Delete the file when the old address stops getting traffic.
+
+### URLs that redirect on their own
+
+Search Console reports these four addresses as a page with a redirect. Each
+one is correct. Do not try to remove them:
+
+- `http://hesamrad.com/` goes to HTTPS.
+- `http://www.hesamrad.com/` and `https://www.hesamrad.com/` go to the address
+  without `www`.
+- An address without a slash at the end, such as `/projects`, goes to the same
+  address with a slash.
+
+The last one comes from a link somewhere outside this site. Every link in the
+site, in the sitemap, and in the feed already has the slash.
+
 ## The campaign switch
 
 `campaignIsLive` in `config.php` controls the Zero to One campaign.

--- a/config.php
+++ b/config.php
@@ -462,6 +462,26 @@ return [
         'pages' => [
             'path' => '{filename}/',
         ],
+
+        /*
+         * URLs that used to have a page and now point somewhere else.
+         *
+         * The site is static and GitHub Pages cannot send a 301, so each item
+         * builds a stub page that redirects with a meta refresh. See
+         * _layouts/redirect.blade.php.
+         *
+         * `redirectFrom` is the old path without the leading or trailing slash,
+         * and it decides where the file is written. The filename does not, which
+         * is what lets a nested URL such as blog/some-post live in a flat
+         * directory. `redirectTo` is the destination, written as a site-relative
+         * path with both slashes.
+         *
+         * Delete an item once the old URL stops getting traffic. A redirect that
+         * nothing follows is a page a crawler still has to fetch.
+         */
+        'redirects' => [
+            'path' => fn($page) => trim($page->redirectFrom, '/').'/',
+        ],
     ],
 
     /**

--- a/listeners/GenerateSitemap.php
+++ b/listeners/GenerateSitemap.php
@@ -35,7 +35,9 @@ class GenerateSitemap
 
         collect($jigsaw->getOutputPaths())
             ->reject(function ($path) use ($jigsaw) {
-                return $this->isExcluded($path) || $this->isNoIndex($jigsaw, $path);
+                return $this->isExcluded($path)
+                    || $this->isNoIndex($jigsaw, $path)
+                    || $this->isRedirect($jigsaw, $path);
             })
             ->each(function ($path) use ($baseUrl, $destination, $sitemap, $jigsaw) {
                 $sitemap->addItem(
@@ -70,6 +72,34 @@ class GenerateSitemap
         }
 
         return str_contains(strtolower($page->getRobotsStatus()), 'noindex');
+    }
+
+    /**
+     * Whether the page is a redirect stub rather than a destination.
+     *
+     * A redirect belongs in no sitemap: the file asks a crawler to leave for
+     * another URL, and that other URL is the one listed. The test reads the
+     * `redirectTo` property, so a stub cannot be added without leaving.
+     *
+     * The `noindex` test above does not cover these. A redirect stub carries no
+     * robots directive on purpose, because a `noindex` would stop a crawler
+     * folding the old URL into the new one.
+     */
+    public function isRedirect(Jigsaw $jigsaw, $path)
+    {
+        $page = $jigsaw->getPages()[$path] ?? null;
+
+        if (! $page) {
+            return false;
+        }
+
+        // Do not use `empty` or `isset` on this. Front matter arrives through
+        // `__get`, and PHP asks `__isset` first, which a collection item does
+        // not answer for front matter. Both functions then report the value
+        // missing while a plain read returns it. Compare the value instead.
+        $destination = $page->redirectTo;
+
+        return is_string($destination) && trim($destination) !== '';
     }
 
     protected function url($baseUrl, $destination, $path)

--- a/source/_layouts/redirect.blade.php
+++ b/source/_layouts/redirect.blade.php
@@ -1,0 +1,43 @@
+{{--
+    A standing redirect for a URL that no longer has a page.
+
+    GitHub Pages serves static files and cannot send a 301, so a stub page is
+    the only redirect this site can issue. Search engines treat a meta refresh
+    with a zero delay as a redirect and follow it, and the canonical link names
+    the destination a second time so the two signals agree.
+
+    The page carries no `noindex`. A `noindex` here would tell a crawler to drop
+    the old URL instead of folding it into the new one, which is the opposite of
+    what a redirect is for. The sitemap listener leaves these pages out on the
+    `redirectTo` property instead.
+
+    Nothing on this page loads a stylesheet or a script bundle. A reader is here
+    for a few milliseconds, and a build asset that fails to load would leave them
+    looking at an error instead of the page they asked for.
+--}}
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Moved</title>
+    <link rel="canonical" href="{{ $page->baseUrl }}{{ $page->redirectTo }}">
+    <meta http-equiv="refresh" content="0; url={{ $page->redirectTo }}">
+    <style>
+        body {
+            margin: 0;
+            padding: 3rem 1.5rem;
+            font-family: system-ui, sans-serif;
+            line-height: 1.6;
+        }
+    </style>
+</head>
+
+<body>
+    <p>This page moved. If your browser doesn't take you there,
+        <a href="{{ $page->redirectTo }}">follow this link</a>.
+    </p>
+</body>
+
+</html>

--- a/source/_redirects/blog-i-dont-code-the-way-i-used-to.md
+++ b/source/_redirects/blog-i-dont-code-the-way-i-used-to.md
@@ -1,0 +1,5 @@
+---
+extends: _layouts.redirect
+redirectFrom: blog/i-dont-code-the-way-i-used-to
+redirectTo: /blog/
+---

--- a/source/_redirects/blog-laravel-13-vs-laravel-12.md
+++ b/source/_redirects/blog-laravel-13-vs-laravel-12.md
@@ -1,0 +1,5 @@
+---
+extends: _layouts.redirect
+redirectFrom: blog/laravel-13-vs-laravel-12
+redirectTo: /blog/
+---

--- a/source/_redirects/english.md
+++ b/source/_redirects/english.md
@@ -1,0 +1,5 @@
+---
+extends: _layouts.redirect
+redirectFrom: english
+redirectTo: /
+---

--- a/source/_redirects/resume.md
+++ b/source/_redirects/resume.md
@@ -1,0 +1,5 @@
+---
+extends: _layouts.redirect
+redirectFrom: resume
+redirectTo: /about/
+---

--- a/source/about.blade.php
+++ b/source/about.blade.php
@@ -49,7 +49,10 @@ disableContact: true
                     people who depend on it.
                 </p>
                 <p>
-                    So I started working independently in late 2025.
+                    So I started working independently in late 2025. If you're weighing one engineer against an
+                    agency, I've written down
+                    <a href="/blog/agency-or-one-independent-engineer/">the honest comparison</a>, including the
+                    jobs an agency is the better answer for.
                 </p>
             </div>
         </div>

--- a/source/services.blade.php
+++ b/source/services.blade.php
@@ -81,7 +81,9 @@ contactIntro: "That's enough for me to tell you whether this is a week of work o
             <div class="section-head section-head--start">
                 <h2>What working with me is like.</h2>
                 <p class="dim">You should know how this goes before you commit to it. Nothing here waits until after
-                the contract is signed to show up.</p>
+                the contract is signed to show up. If you're comparing this against
+                <a href="/blog/agency-or-one-independent-engineer/">hiring an agency</a>, that post lays out both
+                sides.</p>
             </div>
 
             <ol class="steps">


### PR DESCRIPTION
Four Search Console reports, handled one commit each.

## What changed

**404 (3 URLs).** `/english/`, `/blog/laravel-13-vs-laravel-12/` and `/blog/i-dont-code-the-way-i-used-to/` all had pages once and now return 404. GitHub Pages serves static files and cannot send a 301, so a new `redirects` collection builds a stub page for each: a zero-delay meta refresh plus a canonical link to the destination. Search engines follow both.

**Excluded by noindex (1 URL).** `/resume/` was removed in 0fe12d1's history (commit `74c919e`). Nothing carries that directive any more and the URL now 404s, so the report describes the state before the removal. It redirects to `/about/`, which covers the same ground.

**Crawled, currently not indexed (2 URLs).** `/blog/agency-or-one-independent-engineer/` is technically fine: canonical, `index,follow`, `BlogPosting` + `FAQPage` + breadcrumbs, over 2,000 words. Its only inbound links were the blog listing, one FAQ answer and the end of the other post. The about page and the services page both reach the point where a reader is choosing between one engineer and an agency, so both now link to it. `/feed.xml` is left alone; a feed is for subscribing, and crawled-not-indexed is the normal outcome for one.

**Page with redirect (4 URLs).** No code change. All four are canonicalization working as intended, verified live: `http://hesamrad.com/` to HTTPS, both `www` forms to the apex, and `/projects` to `/projects/`. Nothing in the site, the sitemap or the feed links to any of them, so the last one comes from an external link. The README now records this so the next person doesn't go looking for a fix.

## For the reviewer

- The sitemap listener keeps redirect stubs out on a new `redirectTo` test. That test deliberately avoids `empty()`: front matter reaches a Jigsaw collection item through `__get`, PHP consults `__isset` first, and a collection item doesn't answer it for front matter. `empty()` therefore reports a present value as missing. This cost a debugging round; the comment in the listener explains it.
- The stubs carry no `noindex`. A `noindex` would tell a crawler to drop the old URL rather than fold it into the new one, which is the opposite of what a redirect is for. They stay out of the sitemap, the blog listing and the feed by other means.
- `redirectFrom` decides the output path, not the filename. That's what lets a nested URL such as `blog/some-post` live in a flat `source/_redirects/` directory.
- Verified against a production build: canonicals resolve to `https://hesamrad.com/...`, the stubs exist at the right paths, and the sitemap contains none of the four redirected URLs.

## Not addressed

`/index.html`, `/about/index.html` and `/blog/index.html` all serve 200 alongside their trailing-slash URL. Search Console hasn't flagged it and the canonical tags already point away from those forms, but it's a real duplicate surface if you want it dealt with separately.