### PR TITLE
seo: rewrite page descriptions so search engines keep them

### DIFF
--- a/source/about.blade.php
+++ b/source/about.blade.php
@@ -7,9 +7,9 @@ disableContact: true
 
 @section('title', 'About Hesam Rad')
 
-@section('description',
-    'Independent software engineer. Eight years building web software for businesses, five of them
-    looking after a single system for one client.')
+{{-- Keep this on one line. A string broken across lines puts a real newline and
+     the indentation inside the content attribute. --}}
+@section('description', 'I build bespoke web software for real businesses, and have since late 2017. One person, start to finish, and still around when it needs changing.')
 
 @section('body')
     <div class="shell section page-head">

--- a/source/blog.blade.php
+++ b/source/blog.blade.php
@@ -15,7 +15,11 @@ disableContact: true
 
 @section('title', 'Blog')
 
-@section('description', 'Notes from the work: whatever I\'m building, using or working out at the time. Written for people who pay for software, not only those who write it.')
+{{-- Say what the writing is about, not which posts are on the page today. A
+     description built from the current posts goes stale the next time one is
+     published, and one that only names the genre gets replaced by a sentence
+     Google picks off the page. --}}
+@section('description', 'I write about software development, the world of business and how the two intersect. You don\'t need a technical background to follow any of it.')
 
 @section('body')
     <div class="shell section page-head">

--- a/source/faq.blade.php
+++ b/source/faq.blade.php
@@ -8,7 +8,10 @@ contactIntro: "Ask it directly. You'll get a straight answer within a day, even 
 
 @section('title', 'Questions')
 
-@section('description', 'What it costs, how long it takes, what you own at the end, and what happens if I\'m unavailable. Every question I get asked before somebody hires me.')
+{{-- Answer the questions here, don't list them. A description that only names
+     the page's own headings gets replaced by a sentence Google picks off the
+     page. --}}
+@section('description', 'You own the code from the first day, it lives in your repository, and you know the price before you commit. The answers people want before we get started.')
 
 @php
     /*

--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -4,10 +4,11 @@
 @section('title', 'Hesam Rad - Independent Software Engineer')
 
 {{-- Keep this description below 120 characters. A phone cuts the search snippet
-     at approximately that length. --}}
-@section('description',
-    'I build the software behind a growing business, and the website in front of it. One man, start
-    to finish.')
+     at approximately that length.
+
+     Keep it on one line. A string broken across lines puts a real newline and
+     the indentation inside the content attribute. --}}
+@section('description', 'I build bespoke web software behind growing businesses, and the websites in front of them. One man, start to finish.')
 
 @section('body')
     {{-- The dot field covers the hero and the figures below it. It must stay on

--- a/source/projects.blade.php
+++ b/source/projects.blade.php
@@ -7,7 +7,9 @@ disableContact: true
 
 @section('title', 'Open Source')
 
-@section('description', 'Small open-source tools I built for my own work and published for anyone to use, plus a free URL shortener run as a non-profit.')
+{{-- Do not name a project here. A description built from the current entries
+     goes stale the next time one is added or retired. --}}
+@section('description', 'Open-source tools I built for my own work, and non-profit tools I run for public use. If one of them helps you, open an issue or send a pull request.')
 
 @section('body')
     <div class="shell section page-head">

--- a/source/services.blade.php
+++ b/source/services.blade.php
@@ -8,7 +8,9 @@ contactIntro: "That's enough for me to tell you whether this is a week of work o
 
 @section('title', 'Services')
 
-@section('description', 'The work I take on and the work I don\'t, how the work runs, what it costs, and how to start.')
+{{-- State what the page offers. A description that only lists the page's own
+     headings gets replaced by a sentence Google picks off the page. --}}
+@section('description', 'You get one engineer who builds all of it: the screens your customers use, the system behind them, and the work that keeps it running.')
 
 @section('body')
     <div class="shell section page-head">

--- a/source/work.blade.php
+++ b/source/work.blade.php
@@ -19,7 +19,11 @@ contactIntro: "A paragraph is enough. I'll tell you whether I've done something 
 
 @section('title', 'Work')
 
-@section('description', 'Selected projects: what the business needed, what I built, and what changed as a result.')
+{{-- Say what the projects are, not which ones are on the page today. A
+     description that lists the current entries goes stale the next time one is
+     added, and one that only lists the page's own headings gets replaced by a
+     sentence Google picks off the page. --}}
+@section('description', 'I built every system here end to end, for real businesses. Every one of them shipped and went into daily use.')
 
 @section('body')
     <div class="shell section page-head">


### PR DESCRIPTION
## What changed

Rewrote the meta description on all seven indexable pages: `/`, `/about`, `/services`, `/work`, `/blog`, `/faq`, `/projects`.

## Why

A `site:hesamrad.com` search showed Google discarding the meta description on `/`, `/services`, `/work`, `/blog` and `/faq`, and substituting text it picked off the page instead. For `/`, `/work` and `/blog` the substitute was the footer pitch in `source/_includes/footer.blade.php:54` plus the footer nav labels.

The tags were not broken. Every page had a correct `<meta name="description">` in the live HTML, and the layout was writing it, the Open Graph tags, the Twitter tags and the JSON-LD `WebPage.description` correctly. Crawl dates in the results postdated the commits that added the descriptions, so it was not staleness either.

The pattern was in the writing. Every rejected description listed what the page contained:

> The work I take on and the work I don't, how the work runs, what it costs, and how to start.

Every kept one made a claim:

> Independent software engineer. Eight years building web software for businesses, five of them looking after a single system for one client.

## The rewrite

Three rules applied to all seven:

1. **State something.** No description is a list of the page's own headings.
2. **Stay off current inventory.** No description names a case study, a post or a package, so adding or retiring one does not make it stale.
3. **Active voice.** `/services`, `/faq` and `/projects` each carried a passive construction; all three are gone.

## Secondary fix

`/` and `/about` used a string broken across two source lines, which put a real newline and the source indentation inside the `content` attribute:

```html
<meta name="description" content="...One man, start
    to finish.">
```

Both are on one line now, with a comment at each explaining why they must stay that way.

## Verification

Built and checked all 19 pages in `build_production/`:

- Seven indexable pages: unique descriptions, 109 to 154 characters, single line, no embedded newlines, no duplicates across the site.
- Each propagates to four places per page: `meta`, `og:description`, `twitter:description`, JSON-LD.
- Four pages report no description (`/english/`, `/resume/`, and two retired post URLs). All four are redirect stubs with `<title>Moved</title>`, a meta refresh and a canonical. Correct, not a gap.
- `/404` has no canonical and `/thank-you` runs short. Both `noindex`.

## For the reviewer

No markup, logic or layout is touched. The diff is descriptions and comments.

Two things noticed and left alone:

- `/blog/no-code-off-the-shelf-or-custom/` has a 62 character title. The brand-suffix logic in the layout correctly suppresses the suffix past 60, but the title itself still truncates in results.
- `/` ends "One man, start to finish" and `/about` ends "One person, start to finish, and still around when it needs changing." Same tail, different noun.

Google rewrites most descriptions regardless of quality, and a `site:` query carries no intent to match against, so that view stays a poor way to judge the result. After this deploys, requesting indexing per URL in Search Console and checking against a real query is the way to tell whether it worked.